### PR TITLE
binding when computing code coverage

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,12 @@ if use_cython:
     ]
     ext_modules = cythonize(
         ext_modules,
-        compiler_directives={'language_level': 3, 'linetrace': LINE_TRACE, 'profile': True, 'binding': LINE_TRACE},
+        compiler_directives={
+            'language_level': 3,
+            'linetrace': LINE_TRACE,
+            'profile': True,
+            'binding': LINE_TRACE,
+        },
     )
 
 else:

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ if use_cython:
     ]
     ext_modules = cythonize(
         ext_modules,
-        compiler_directives={'language_level': 3, 'linetrace': LINE_TRACE, 'profile': True},
+        compiler_directives={'language_level': 3, 'linetrace': LINE_TRACE, 'profile': True, 'binding': LINE_TRACE},
     )
 
 else:


### PR DESCRIPTION
Turn `binding` on may help to get correct code coverage for cython files.
ref: https://github.com/cython/cython/issues/1461