### PR TITLE
All functions

### DIFF
--- a/uttut/pipeline/bian/base.py
+++ b/uttut/pipeline/bian/base.py
@@ -29,12 +29,12 @@ class Edit(ABC):
     '''
 
     def __init__(
-        self,
-        start: int,
-        end: int,
-        replacement,
-        annotation: str = None,
-    ):
+            self,
+            start: int,
+            end: int,
+            replacement,
+            annotation: str = None,
+        ):
         _validate_start_end(start, end)
         self.start, self.end = start, end
         self.replacement = replacement

--- a/uttut/pipeline/bian/edit.py
+++ b/uttut/pipeline/bian/edit.py
@@ -86,11 +86,11 @@ class EditGroup(Group):
 
     def done(self):
         if len(self._edits) == 0:
-            warnings.warn("EditGroup is empty")
             self._edits = list(self._edits)
         else:
             _validate_type_of_each_elements(list(self._edits))
             self._edits = sorted(self._edits, key=lambda e: e.end)  # set -> list
+            self._edits = sorted(self._edits, key=lambda e: e.start)
             _validate_disjoint(self._edits)
         self._is_done = True
 
@@ -120,6 +120,9 @@ class EditGroup(Group):
         edit_group.done()
         return edit_group
 
+    def is_empty(self):
+        return len(self._edits) == 0
+
     def __eq__(self, other):
         self._warn_not_done()
         if not isinstance(other, EditGroup):
@@ -142,4 +145,6 @@ class EditGroup(Group):
             warnings.warn('EditGroup needs validation, please call `done`.')
 
     def __repr__(self):
+        if self.is_empty():
+            return f"EmptyEditGroup"
         return f"{list(self._edits)[0].__class__.__name__}Group"

--- a/uttut/pipeline/bian/lst2lst.py
+++ b/uttut/pipeline/bian/lst2lst.py
@@ -1,0 +1,28 @@
+from .edit import EditGroup
+from .utils import (
+    _transform_sequence,
+    _gen_inverse_edit_group,
+)
+
+
+def apply(input_lst: list, edit_group: EditGroup) -> list:
+    n_edit = len(edit_group)
+    output = [[]] * (2 * n_edit + 1)
+    output_lst = _transform_sequence(
+        input_seq=input_lst,
+        edit_group=edit_group,
+        output=output,
+    )
+    return sum(output_lst, [])
+
+
+def inverse(input_lst: list, edit_group: EditGroup) -> EditGroup:
+    inverse_edit_group = _gen_inverse_edit_group(
+        input_seq=input_lst,
+        edit_group=edit_group,
+    )
+    assert len(inverse_edit_group) == len(edit_group)
+    return inverse_edit_group
+
+
+# TODO label

--- a/uttut/pipeline/bian/lst2lst.py
+++ b/uttut/pipeline/bian/lst2lst.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from .edit import EditGroup
 from .utils import (
     _transform_sequence,
@@ -5,7 +7,8 @@ from .utils import (
 )
 
 
-def apply(input_lst: list, edit_group: EditGroup) -> list:
+def apply(input_lst: list, edit_group: EditGroup) -> List[str]:
+    output: List[list]
     n_edit = len(edit_group)
     output = [[]] * (2 * n_edit + 1)
     output_lst = _transform_sequence(

--- a/uttut/pipeline/bian/lst2str.py
+++ b/uttut/pipeline/bian/lst2str.py
@@ -1,41 +1,16 @@
-from typing import List, Tuple
+from typing import List
 
-from .edit import EditGroup
 from .span import SpanGroup
-from uttut.pipeline.bian import str2str
 
 
-def apply(
-        input_lst: List[str],
-        span_group: SpanGroup,
-        edit_group: EditGroup,
-    ) -> List[str]:
+def apply(input_lst: List[str], span_group: SpanGroup) -> List[str]:
 
     _validate_compatibility(input_lst, span_group)
 
-    # 1. apply span group (list -> str)
+    # apply span group (list -> str)
     output_str = ''.join(input_lst)
 
-    # 2. apply edit group (str -> str)
-    output_str = str2str.apply(output_str, edit_group)
-
     return output_str
-
-
-def inverse(
-        input_lst: List[str],
-        span_group: SpanGroup,
-        edit_group: EditGroup,
-    ) -> Tuple[EditGroup, SpanGroup]:
-
-    _validate_compatibility(input_lst, span_group)
-
-    # inverse edit group only
-    inverse_edit_group = EditGroup.add_all([])
-    if not edit_group.is_empty():
-        inverse_edit_group = str2str.inverse(''.join(input_lst), edit_group)
-
-    return inverse_edit_group, span_group
 
 
 def _validate_compatibility(input_lst: List[str], span_group: SpanGroup):

--- a/uttut/pipeline/bian/lst2str.py
+++ b/uttut/pipeline/bian/lst2str.py
@@ -3,7 +3,7 @@ from typing import List
 from .span import SpanGroup
 
 
-def apply(input_lst: List[str], span_group: SpanGroup) -> List[str]:
+def apply(input_lst: List[str], span_group: SpanGroup) -> str:
 
     _validate_compatibility(input_lst, span_group)
 

--- a/uttut/pipeline/bian/lst2str.py
+++ b/uttut/pipeline/bian/lst2str.py
@@ -1,0 +1,46 @@
+from typing import List, Tuple
+
+from .edit import EditGroup
+from .span import SpanGroup
+from uttut.pipeline.bian import str2str
+
+
+def apply(
+        input_lst: List[str],
+        span_group: SpanGroup,
+        edit_group: EditGroup,
+    ) -> List[str]:
+
+    _validate_compatibility(input_lst, span_group)
+
+    # 1. apply span group (list -> str)
+    output_str = ''.join(input_lst)
+
+    # 2. apply edit group (str -> str)
+    output_str = str2str.apply(output_str, edit_group)
+
+    return output_str
+
+
+def inverse(
+        input_lst: List[str],
+        span_group: SpanGroup,
+        edit_group: EditGroup,
+    ) -> Tuple[EditGroup, SpanGroup]:
+
+    _validate_compatibility(input_lst, span_group)
+
+    # inverse edit group only
+    inverse_edit_group = EditGroup.add_all([])
+    if not edit_group.is_empty():
+        inverse_edit_group = str2str.inverse(''.join(input_lst), edit_group)
+
+    return inverse_edit_group, span_group
+
+
+def _validate_compatibility(input_lst: List[str], span_group: SpanGroup):
+    if len(input_lst) != len(span_group):
+        raise ValueError('Input list and span group have different length.')
+    for i, (token, span) in enumerate(zip(input_lst, span_group)):
+        if len(token) != span.end - span.start:
+            raise ValueError(f"{i}-th element is not compatible.")

--- a/uttut/pipeline/bian/span.py
+++ b/uttut/pipeline/bian/span.py
@@ -49,7 +49,6 @@ class SpanGroup(Group):
 
     def done(self):
         if len(self._spans) == 0:
-            warnings.warn("SpanGroup is empty")
             self._spans = list(self._spans)
         else:
             self._spans = sorted(self._spans, key=lambda e: e.end)  # set -> list
@@ -75,6 +74,9 @@ class SpanGroup(Group):
                 raise ValueError('Number of elements should = 2.')
         span_group.done()
         return span_group
+
+    def is_empty(self):
+        return len(self._spans) == 0
 
     def __eq__(self, other):
         self._warn_not_done()

--- a/uttut/pipeline/bian/str2lst.py
+++ b/uttut/pipeline/bian/str2lst.py
@@ -1,0 +1,72 @@
+from typing import List, Tuple
+
+from .edit import EditGroup
+from .span import SpanGroup
+from uttut.pipeline.bian import str2str
+
+
+def apply(
+        input_str: str,
+        edit_group: EditGroup,
+        span_group: SpanGroup,
+    ) -> List[str]:
+
+    # 1. apply edits (str -> str)
+    output_str = input_str
+    if not edit_group.is_empty():
+        output_str = str2str.apply(input_str, edit_group)
+
+    # 2. apply spans (str -> list)
+    output_lst = [''] * len(span_group)
+    for i, span in enumerate(span_group):
+        output_lst[i] = output_str[span.start: span.end]
+
+    return output_lst
+
+
+def inverse(
+        input_str: str,
+        edit_group: EditGroup,
+        span_group: SpanGroup,
+    ) -> Tuple[EditGroup, SpanGroup]:
+
+    # inverse edit group only
+    inverse_edit_group = EditGroup.add_all([])
+    if not edit_group.is_empty():
+        inverse_edit_group = str2str.inverse(input_str, edit_group)
+
+    return inverse_edit_group, span_group
+
+
+def gen_span_group(input_str: str, tokens: List[str]) -> SpanGroup:
+    '''Compare string and tokens then generate SpanGroup'''
+
+    if input_str != ''.join(tokens):
+        raise ValueError('input_str and tokens are not compatible')
+
+    shift = 0
+    span_group = SpanGroup()
+    for token in tokens:
+        start = input_str.find(token, shift)
+        end = start + len(token)
+        span_group.add(start, end)
+        shift = end
+    span_group.done()
+    assert len(span_group) == len(tokens)
+    return span_group
+
+
+def gen_edit_group(input_str: str, tokens: List[str]) -> EditGroup:
+    '''Compare string and tokens then generate EditGroup'''
+
+    shift = 0
+    edit_group = EditGroup()
+    for token in tokens:
+        start = input_str.find(token, shift)
+        if start == -1:
+            ValueError('input_str and tokens are not compatible')
+        if input_str[shift: start] != '':
+            edit_group.add(shift, start, '')
+        shift = start + len(token)
+    edit_group.done()
+    return edit_group

--- a/uttut/pipeline/bian/str2lst.py
+++ b/uttut/pipeline/bian/str2lst.py
@@ -4,16 +4,20 @@ from .edit import EditGroup
 from .span import SpanGroup
 
 
-def apply(
-        input_str: str,
-        span_group: SpanGroup,
-    ) -> List[str]:
+def apply(input_str: str, span_group: SpanGroup) -> List[str]:
+
+    _validate_compatibility(input_str, span_group)
 
     output_lst = [''] * len(span_group)
     for i, span in enumerate(span_group):
         output_lst[i] = input_str[span.start: span.end]
 
     return output_lst
+
+
+def _validate_compatibility(input_str: str, span_group: SpanGroup):
+    if len(input_str) != span_group[-1].end:
+        raise ValueError('Input list and span group is not compatible.')
 
 
 def gen_span_group(input_str: str, tokens: List[str]) -> SpanGroup:

--- a/uttut/pipeline/bian/str2lst.py
+++ b/uttut/pipeline/bian/str2lst.py
@@ -1,41 +1,19 @@
-from typing import List, Tuple
+from typing import List
 
 from .edit import EditGroup
 from .span import SpanGroup
-from uttut.pipeline.bian import str2str
 
 
 def apply(
         input_str: str,
-        edit_group: EditGroup,
         span_group: SpanGroup,
     ) -> List[str]:
 
-    # 1. apply edits (str -> str)
-    output_str = input_str
-    if not edit_group.is_empty():
-        output_str = str2str.apply(input_str, edit_group)
-
-    # 2. apply spans (str -> list)
     output_lst = [''] * len(span_group)
     for i, span in enumerate(span_group):
-        output_lst[i] = output_str[span.start: span.end]
+        output_lst[i] = input_str[span.start: span.end]
 
     return output_lst
-
-
-def inverse(
-        input_str: str,
-        edit_group: EditGroup,
-        span_group: SpanGroup,
-    ) -> Tuple[EditGroup, SpanGroup]:
-
-    # inverse edit group only
-    inverse_edit_group = EditGroup.add_all([])
-    if not edit_group.is_empty():
-        inverse_edit_group = str2str.inverse(input_str, edit_group)
-
-    return inverse_edit_group, span_group
 
 
 def gen_span_group(input_str: str, tokens: List[str]) -> SpanGroup:

--- a/uttut/pipeline/bian/str2str.py
+++ b/uttut/pipeline/bian/str2str.py
@@ -1,0 +1,26 @@
+from .edit import EditGroup
+from .utils import (
+    _transform_sequence,
+    _gen_inverse_edit_group,
+)
+
+
+def apply(input_str: str, edit_group: EditGroup) -> str:
+    n_edit = len(edit_group)
+    output = [''] * (2 * n_edit + 1)
+    output_lst = _transform_sequence(
+        input_seq=input_str,
+        edit_group=edit_group,
+        output=output,
+    )
+    output_str = ''.join(output_lst)
+    return output_str
+
+
+def inverse(input_str: str, edit_group: EditGroup) -> EditGroup:
+    inverse_edit_group = _gen_inverse_edit_group(
+        input_seq=input_str,
+        edit_group=edit_group,
+    )
+    assert len(inverse_edit_group) == len(edit_group)
+    return inverse_edit_group

--- a/uttut/pipeline/bian/tests/test_lst2lst.py
+++ b/uttut/pipeline/bian/tests/test_lst2lst.py
@@ -1,0 +1,62 @@
+import pytest
+
+from ..edit import EditGroup
+from uttut.pipeline.bian import lst2lst
+
+
+test_cases = [
+    pytest.param(
+        list('我想要喝200元的珍奶10杯'),
+        EditGroup.add_all([(4, 7, list('_int_')), (11, 13, list('_int_'))]),
+        list('我想要喝_int_元的珍奶_int_杯'),
+        EditGroup.add_all([(4, 9, list('200')), (13, 18, list('10'))]),
+        id='modify',
+    ),
+    pytest.param(
+        list('我想喝珍奶'),
+        EditGroup.add_all([(0, 0, list('其實')), (0, 1, ['妳']), (1, 1, ['不']),
+                           (3, 5, list('多多綠')), (5, 5, list('對吧！'))]),
+        list('其實妳不想喝多多綠對吧！'),
+        EditGroup.add_all([(0, 2, []), (2, 3, ['我']), (3, 4, []),
+                           (6, 9, list('珍奶')), (9, 12, [])]),
+        id='insert',
+    ),
+    pytest.param(
+        list('我不想喝珍奶'),
+        EditGroup.add_all([(1, 2, [])]),
+        list('我想喝珍奶'),
+        EditGroup.add_all([(1, 1, ['不'])]),
+        id='delete',
+    ),
+    pytest.param(
+        ['這個', '句子', '沒有', '改變'],
+        EditGroup.add_all([]),
+        ['這個', '句子', '沒有', '改變'],
+        EditGroup.add_all([]),
+        id='identity',
+    ),
+]
+
+
+@pytest.mark.parametrize("input_lst,forward_edits,output_lst,inverse_edits", test_cases)
+def test_forward_apply(input_lst, forward_edits, output_lst, inverse_edits):
+    output = lst2lst.apply(input_lst, forward_edits)
+    assert output_lst == output
+
+
+@pytest.mark.parametrize("input_lst,forward_edits,output_lst,inverse_edits", test_cases)
+def test_backward_apply(input_lst, forward_edits, output_lst, inverse_edits):
+    output = lst2lst.apply(output_lst, inverse_edits)
+    assert input_lst == output
+
+
+@pytest.mark.parametrize("input_lst,forward_edits,output_lst,inverse_edits", test_cases)
+def test_forward_inverse(input_lst, forward_edits, output_lst, inverse_edits):
+    output = lst2lst.inverse(input_lst, forward_edits)
+    assert inverse_edits == output
+
+
+@pytest.mark.parametrize("input_lst,forward_edits,output_lst,inverse_edits", test_cases)
+def test_backward_inverse(input_lst, forward_edits, output_lst, inverse_edits):
+    output = lst2lst.inverse(output_lst, inverse_edits)
+    assert forward_edits == output

--- a/uttut/pipeline/bian/tests/test_span_group.py
+++ b/uttut/pipeline/bian/tests/test_span_group.py
@@ -7,7 +7,7 @@ from ..span import Span, SpanGroup
 def test_correctly_init():
     span_group = SpanGroup()
     assert span_group._is_done is False
-    assert span_group._spans == set()
+    assert span_group.is_empty() is True
     assert len(span_group) == 0
 
 
@@ -32,8 +32,21 @@ def test_add_all():
 
 
 def test_add_all_empty():
-    with pytest.warns(UserWarning, match='SpanGroup is empty'):
-        SpanGroup.add_all([])
+    span_group = SpanGroup.add_all([])
+    assert span_group.is_empty() is True
+
+
+def test_not_done_warning():
+    span_group = SpanGroup()
+    with pytest.warns(UserWarning, match='SpanGroup needs validation, please call `done`.'):
+        len(span_group)
+
+
+def test_not_done_error():
+    span_group = SpanGroup()
+    span_group.add(1, 3)
+    with pytest.raises(RuntimeError, message='Please call `done` first.'):
+        span_group[0]
 
 
 @pytest.mark.parametrize(
@@ -48,7 +61,6 @@ def test_add_fails(obj, error_type):
         SpanGroup.add_all(obj)
 
 
-@pytest.mark.filterwarnings("ignore")
 @pytest.mark.parametrize(
     "group1,group2",
     [
@@ -106,10 +118,3 @@ def test_validate_disjoint(objs):
 )
 def test_representation(name, group):
     assert name == repr(group)
-
-
-def test_getitem_fails():
-    span_group = SpanGroup()
-    span_group.add(0, 2)
-    with pytest.raises(RuntimeError):
-        span_group[0]

--- a/uttut/pipeline/bian/tests/test_str2lst.py
+++ b/uttut/pipeline/bian/tests/test_str2lst.py
@@ -75,6 +75,19 @@ def test_gen_span_group(input_str, tokens, span_group):
 
 
 @pytest.mark.parametrize(
+    'input_str,tokens',
+    [
+        pytest.param('我想要喝200元的珍奶10杯', ['薄餡', '亂入'], id='zh_all_mismatch'),
+        pytest.param("I've been to Japan.", ["I", "'", "ve", "been", "to", "Japan", "."],
+                     id='us lack of space'),
+    ],
+)
+def test_gen_span_group_fail(input_str, tokens):
+    with pytest.raises(ValueError, message='input_str and tokens are not compatible.'):
+        str2lst.gen_span_group(input_str, tokens)
+
+
+@pytest.mark.parametrize(
     "input_str,tokens,edit_group",
     [
         pytest.param(

--- a/uttut/pipeline/bian/tests/test_str2lst.py
+++ b/uttut/pipeline/bian/tests/test_str2lst.py
@@ -9,79 +9,83 @@ test_cases = [
     pytest.param(
         '我想要喝200元的珍奶10杯',
         ['我', '想要', '喝', '200元', '的', '珍奶', '10杯'],
-        EditGroup.add_all([]),
         SpanGroup.add_all(
             [(0, 1), (1, 3), (3, 4), (4, 8), (8, 9), (9, 11), (11, 14)]),
-        EditGroup.add_all([]),
         id='jieba',
     ),
     pytest.param(
         '我想要喝 200 元的珍奶 10 杯',
         ['我', '想要', '喝', ' ', '200', ' ', '元', '的', '珍奶', ' ', '10', ' ', '杯'],
-        EditGroup.add_all([]),
         SpanGroup.add_all(
             [(0, 1), (1, 3), (3, 4), (4, 5), (5, 8), (8, 9), (9, 10),
              (10, 11), (11, 13), (13, 14), (14, 16), (16, 17), (17, 18)]),
-        EditGroup.add_all([]),
         id='jieba with space',
     ),
     pytest.param(
-        "I've been to Japan.",
+        "I'vebeentoJapan.",
         ["I", "'", "ve", "been", "to", "Japan", "."],
-        EditGroup.add_all([(4, 5, ''), (9, 10, ''), (12, 13, '')]),
         SpanGroup.add_all(
             [(0, 1), (1, 2), (2, 4), (4, 8), (8, 10), (10, 15), (15, 16)]),
-        EditGroup.add_all([(4, 4, ' '), (8, 8, ' '), (10, 10, ' ')]),
-        id='nltk punct',
+        id='nltk punct after str2tr',
     ),
     pytest.param(
-        "I've been to Japan.",
+        "I'vebeentoJapan.",
         ["I've", "been", "to", "Japan", "."],
-        EditGroup.add_all([(4, 5, ''), (9, 10, ''), (12, 13, '')]),
         SpanGroup.add_all(
             [(0, 4), (4, 8), (8, 10), (10, 15), (15, 16)]),
-        EditGroup.add_all([(4, 4, ' '), (8, 8, ' '), (10, 10, ' ')]),
-        id='nltk',
+        id='nltk after str2tr',
     ),
 ]
 
 
-@pytest.mark.parametrize("input_str,tokens,edit_group,span_group,inverse_edit_group", test_cases)
-def test_forward_apply(input_str, tokens, edit_group, span_group, inverse_edit_group):
-    output = str2lst.apply(input_str, edit_group, span_group)
+@pytest.mark.parametrize("input_str,tokens,span_group,", test_cases)
+def test_forward_apply(input_str, tokens, span_group):
+    output = str2lst.apply(input_str, span_group)
     assert tokens == output
 
 
-@pytest.mark.parametrize("input_str,tokens,edit_group,span_group,inverse_edit_group", test_cases)
-def test_backward_apply(input_str, tokens, edit_group, span_group, inverse_edit_group):
-    output = lst2str.apply(tokens, span_group, inverse_edit_group)
+@pytest.mark.parametrize("input_str,tokens,span_group,", test_cases)
+def test_backward_apply(input_str, tokens, span_group):
+    output = lst2str.apply(tokens, span_group)
     assert input_str == output
 
 
-@pytest.mark.parametrize("input_str,tokens,edit_group,span_group,inverse_edit_group", test_cases)
-def test_forward_inverse(input_str, tokens, edit_group, span_group, inverse_edit_group):
-    output = str2lst.inverse(input_str, edit_group, span_group)
-    assert (inverse_edit_group, span_group) == output
+@pytest.mark.parametrize("input_str,tokens,span_group,", test_cases)
+def test_gen_span_group(input_str, tokens, span_group):
+    output = str2lst.gen_span_group(input_str, tokens)
+    assert span_group == output
 
 
-@pytest.mark.parametrize("input_str,tokens,edit_group,span_group,inverse_edit_group", test_cases)
-def test_backward_inverse(input_str, tokens, edit_group, span_group, inverse_edit_group):
-    output = lst2str.inverse(tokens, span_group, inverse_edit_group)
-    assert (edit_group, span_group) == output
-
-
-@pytest.mark.parametrize("input_str,tokens,edit_group,span_group,inverse_edit_group", test_cases)
-def test_gen_span_group(input_str, tokens, edit_group, span_group, inverse_edit_group):
-    if edit_group.is_empty():
-        output = str2lst.gen_span_group(input_str, tokens)
-        assert span_group == output
-    else:
-        with pytest.raises(ValueError, message='input_str and tokens are not compatible.'):
-            str2lst.gen_span_group(input_str, tokens)
-
-
-@pytest.mark.parametrize("input_str,tokens,edit_group,span_group,inverse_edit_group", test_cases)
-def test_gen_edit_group(input_str, tokens, edit_group, span_group, inverse_edit_group):
+@pytest.mark.parametrize(
+    "input_str,tokens,edit_group",
+    [
+        pytest.param(
+            '我想要喝200元的珍奶10杯',
+            ['我', '想要', '喝', '200元', '的', '珍奶', '10杯'],
+            EditGroup.add_all([]),
+            id='jieba',
+        ),
+        pytest.param(
+            '我想要喝 200 元的珍奶 10 杯',
+            ['我', '想要', '喝', ' ', '200', ' ', '元', '的', '珍奶', ' ', '10', ' ', '杯'],
+            EditGroup.add_all([]),
+            id='jieba with space',
+        ),
+        pytest.param(
+            "I've been to Japan.",
+            ["I", "'", "ve", "been", "to", "Japan", "."],
+            EditGroup.add_all([(4, 5, ''), (9, 10, ''), (12, 13, '')]),
+            id='nltk punct True',
+        ),
+        pytest.param(
+            "I've been to Japan.",
+            ["I've", "been", "to", "Japan", "."],
+            EditGroup.add_all([(4, 5, ''), (9, 10, ''), (12, 13, '')]),
+            id='nltk punct False',
+        ),
+    ],
+)
+def test_gen_edit_group(input_str, tokens, edit_group):
     output = str2lst.gen_edit_group(input_str, tokens)
     assert edit_group == output
 
@@ -109,7 +113,4 @@ def test_gen_edit_group_fail(input_str, tokens):
 )
 def test_incompatible_lst2str(input_lst, span_group):
     with pytest.raises(ValueError):
-        lst2str.apply(input_lst, span_group, EditGroup.add_all([]))
-
-    with pytest.raises(ValueError):
-        lst2str.inverse(input_lst, span_group, EditGroup.add_all([]))
+        lst2str.apply(input_lst, span_group)

--- a/uttut/pipeline/bian/tests/test_str2lst.py
+++ b/uttut/pipeline/bian/tests/test_str2lst.py
@@ -50,6 +50,24 @@ def test_backward_apply(input_str, tokens, span_group):
     assert input_str == output
 
 
+def test_incompatible_str2lst():
+    with pytest.raises(ValueError):
+        str2lst.apply('薄餡亂入', SpanGroup.add_all([(0, 1), (1, 2)]))
+
+
+@pytest.mark.parametrize(
+    'input_lst,span_group',
+    [
+        pytest.param(['薄餡', '亂入'], SpanGroup.add_all([(0, 1)]), id='length'),
+        pytest.param(['我', '想要', '喝', '多多綠'],
+                     SpanGroup.add_all([(0, 1), (1, 3), (3, 5), (5, 8)]), id='element'),
+    ],
+)
+def test_incompatible_lst2str(input_lst, span_group):
+    with pytest.raises(ValueError):
+        lst2str.apply(input_lst, span_group)
+
+
 @pytest.mark.parametrize("input_str,tokens,span_group,", test_cases)
 def test_gen_span_group(input_str, tokens, span_group):
     output = str2lst.gen_span_group(input_str, tokens)
@@ -101,16 +119,3 @@ def test_gen_edit_group(input_str, tokens, edit_group):
 def test_gen_edit_group_fail(input_str, tokens):
     with pytest.raises(ValueError, message='input_str and tokens are not compatible.'):
         str2lst.gen_edit_group(input_str, tokens)
-
-
-@pytest.mark.parametrize(
-    'input_lst,span_group',
-    [
-        pytest.param(['薄餡', '亂入'], SpanGroup.add_all([(0, 1)]), id='length'),
-        pytest.param(['我', '想要', '喝', '多多綠'],
-                     SpanGroup.add_all([(0, 1), (1, 3), (3, 5), (5, 8)]), id='element'),
-    ],
-)
-def test_incompatible_lst2str(input_lst, span_group):
-    with pytest.raises(ValueError):
-        lst2str.apply(input_lst, span_group)

--- a/uttut/pipeline/bian/tests/test_str2lst.py
+++ b/uttut/pipeline/bian/tests/test_str2lst.py
@@ -1,0 +1,87 @@
+import pytest
+
+from ..edit import EditGroup
+from ..span import SpanGroup
+from uttut.pipeline.bian import str2lst
+
+
+test_cases = [
+    pytest.param(
+        '我想要喝200元的珍奶10杯',
+        ['我', '想要', '喝', '200元', '的', '珍奶', '10杯'],
+        EditGroup.add_all([]),
+        SpanGroup.add_all(
+            [(0, 1), (1, 3), (3, 4), (4, 8), (8, 9), (9, 11), (11, 14)]),
+        EditGroup.add_all([]),
+        id='jieba',
+    ),
+    pytest.param(
+        '我想要喝 200 元的珍奶 10 杯',
+        ['我', '想要', '喝', ' ', '200', ' ', '元', '的', '珍奶', ' ', '10', ' ', '杯'],
+        EditGroup.add_all([]),
+        SpanGroup.add_all(
+            [(0, 1), (1, 3), (3, 4), (4, 5), (5, 8), (8, 9), (9, 10),
+             (10, 11), (11, 13), (13, 14), (14, 16), (16, 17), (17, 18)]),
+        EditGroup.add_all([]),
+        id='jieba with space',
+    ),
+    pytest.param(
+        "I've been to Japan.",
+        ["I", "'", "ve", "been", "to", "Japan", "."],
+        EditGroup.add_all([(4, 5, ''), (9, 10, ''), (12, 13, '')]),
+        SpanGroup.add_all(
+            [(0, 1), (1, 2), (2, 4), (4, 8), (8, 10), (10, 15), (15, 16)]),
+        EditGroup.add_all([(4, 4, ' '), (8, 8, ' '), (10, 10, ' ')]),
+        id='nltk punct',
+    ),
+    pytest.param(
+        "I've been to Japan.",
+        ["I've", "been", "to", "Japan", "."],
+        EditGroup.add_all([(4, 5, ''), (9, 10, ''), (12, 13, '')]),
+        SpanGroup.add_all(
+            [(0, 4), (4, 8), (8, 10), (10, 15), (15, 16)]),
+        EditGroup.add_all([(4, 4, ' '), (8, 8, ' '), (10, 10, ' ')]),
+        id='nltk',
+    ),
+]
+
+
+@pytest.mark.parametrize("input_str,tokens,edit_group,span_group,inverse_edit_group", test_cases)
+def test_apply(input_str, tokens, edit_group, span_group, inverse_edit_group):
+    output = str2lst.apply(input_str, span_group, edit_group)
+    assert tokens == output
+
+
+@pytest.mark.parametrize("input_str,tokens,edit_group,span_group,inverse_edit_group", test_cases)
+def test_inverse(input_str, tokens, edit_group, span_group, inverse_edit_group):
+    output = str2lst.inverse(input_str, span_group, edit_group)
+    assert (inverse_edit_group, span_group) == output
+
+
+@pytest.mark.parametrize("input_str,tokens,edit_group,span_group,inverse_edit_group", test_cases)
+def test_gen_span_group(input_str, tokens, edit_group, span_group, inverse_edit_group):
+    if edit_group.is_empty():
+        output = str2lst.gen_span_group(input_str, tokens)
+        assert span_group == output
+    else:
+        with pytest.raises(ValueError, message='input_str and tokens are not compatible.'):
+            str2lst.gen_span_group(input_str, tokens)
+
+
+@pytest.mark.parametrize("input_str,tokens,edit_group,span_group,inverse_edit_group", test_cases)
+def test_gen_edit_group(input_str, tokens, edit_group, span_group, inverse_edit_group):
+    output = str2lst.gen_edit_group(input_str, tokens)
+    assert edit_group == output
+
+
+@pytest.mark.parametrize(
+    'input_str,tokens',
+    [
+        pytest.param('我想要喝200元的珍奶10杯', ['薄餡', '亂入'], id='zh_all_mismatch'),
+        pytest.param('我想要喝珍奶', ['我', '想要', '喝', '多多綠'], id='zh_part_mismatch'),
+        pytest.param('我想要喝珍奶', ['珍奶', '我', '想要', '喝'], id='zh_different_order'),
+    ],
+)
+def test_gen_edit_group_fail(input_str, tokens):
+    with pytest.raises(ValueError, message='input_str and tokens are not compatible.'):
+        str2lst.gen_edit_group(input_str, tokens)

--- a/uttut/pipeline/bian/tests/test_str2str.py
+++ b/uttut/pipeline/bian/tests/test_str2str.py
@@ -1,0 +1,62 @@
+import pytest
+
+from ..edit import EditGroup
+from uttut.pipeline.bian import str2str
+
+
+test_cases = [
+    pytest.param(
+        '我想要喝200元的珍奶10杯',
+        EditGroup.add_all([(4, 7, '_int_'), (11, 13, '_int_')]),
+        '我想要喝_int_元的珍奶_int_杯',
+        EditGroup.add_all([(4, 9, '200'), (13, 18, '10')]),
+        id='modify',
+    ),
+    pytest.param(
+        '我想喝珍奶',
+        EditGroup.add_all([(0, 0, '其實'), (0, 1, '妳'), (1, 1, '不'),
+                           (3, 5, '多多綠'), (5, 5, '對吧！')]),
+        '其實妳不想喝多多綠對吧！',
+        EditGroup.add_all([(0, 2, ''), (2, 3, '我'), (3, 4, ''),
+                           (6, 9, '珍奶'), (9, 12, '')]),
+        id='insert',
+    ),
+    pytest.param(
+        '我不想喝珍奶',
+        EditGroup.add_all([(1, 2, '')]),
+        '我想喝珍奶',
+        EditGroup.add_all([(1, 1, '不')]),
+        id='delete',
+    ),
+    pytest.param(
+        '這個句子沒有改變',
+        EditGroup.add_all([]),
+        '這個句子沒有改變',
+        EditGroup.add_all([]),
+        id='identity',
+    ),
+]
+
+
+@pytest.mark.parametrize("input_str,forward_edits,output_str,inverse_edits", test_cases)
+def test_forward_apply(input_str, forward_edits, output_str, inverse_edits):
+    output = str2str.apply(input_str, forward_edits)
+    assert output_str == output
+
+
+@pytest.mark.parametrize("input_str,forward_edits,output_str,inverse_edits", test_cases)
+def test_backward_apply(input_str, forward_edits, output_str, inverse_edits):
+    output = str2str.apply(output_str, inverse_edits)
+    assert input_str == output
+
+
+@pytest.mark.parametrize("input_str,forward_edits,output_str,inverse_edits", test_cases)
+def test_forward_inverse(input_str, forward_edits, output_str, inverse_edits):
+    output = str2str.inverse(input_str, forward_edits)
+    assert inverse_edits == output
+
+
+@pytest.mark.parametrize("input_str,forward_edits,output_str,inverse_edits", test_cases)
+def test_backward_inverse(input_str, forward_edits, output_str, inverse_edits):
+    output = str2str.inverse(output_str, inverse_edits)
+    assert forward_edits == output

--- a/uttut/pipeline/bian/utils.py
+++ b/uttut/pipeline/bian/utils.py
@@ -1,12 +1,12 @@
-from typing import List, Sequence
+from typing import List, Sequence, MutableSequence, Union
 
 from .edit import EditGroup
 
 
 def _transform_sequence(
-        input_seq: Sequence,
+        input_seq: Union[str, List[str]],
         edit_group: EditGroup,
-        output: Sequence,
+        output: MutableSequence,
     ) -> Sequence:
     '''
     input_seq: list of str or pure str
@@ -27,7 +27,7 @@ def _transform_sequence(
 
 
 def _gen_inverse_edit_group(
-        input_seq: Sequence,
+        input_seq: Union[str, List[str]],
         edit_group: EditGroup,
     ) -> EditGroup:
     '''

--- a/uttut/pipeline/bian/utils.py
+++ b/uttut/pipeline/bian/utils.py
@@ -1,0 +1,77 @@
+from typing import List, Sequence
+
+from .edit import EditGroup
+
+
+def _transform_sequence(
+        input_seq: Sequence,
+        edit_group: EditGroup,
+        output: Sequence,
+    ) -> Sequence:
+    '''
+    input_seq: list of str or pure str
+    '''
+
+    start = 0
+    i = 0
+    for edit in edit_group:
+        output[i] = input_seq[start: edit.start]
+        output[i + 1] = edit.replacement
+        start = edit.end
+        i += 2
+
+    # tail
+    output[-1] = input_seq[start:]
+
+    return output
+
+
+def _gen_inverse_edit_group(
+        input_seq: Sequence,
+        edit_group: EditGroup,
+    ) -> EditGroup:
+    '''
+    input_seq: list of str or pure str
+    '''
+    if edit_group.is_empty():
+        return EditGroup.add_all([])
+
+    inverse_edit_group = EditGroup()
+    n_edit = len(edit_group)
+
+    dists = get_dist_bt_edit_group(edit_group)
+    dists.append(0)
+
+    start = edit_group[0].start
+
+    for i in range(n_edit):
+        edit = edit_group[i]
+        dist = dists[i]
+        inverse_edit_group.add(
+            start=start,
+            end=start + len(edit.replacement),
+            replacement=input_seq[edit.start: edit.end],
+        )
+        start += len(edit.replacement) + dist
+    inverse_edit_group.done()
+    return inverse_edit_group
+
+
+def get_dist_bt_edit_group(edit_group: EditGroup) -> List[int]:
+    '''Compute the distance between edit_group
+    The distance is the length of sequence.
+    Eg.
+    Given [Edit(0, 1, ''), Edit(4, 7, '')]: [3]  # 4 - 1
+    Given [Edit(0, 3, ''), Edit(3, 4, ''), Edit(8, 11, '')]: [0, 4]
+    Note that the length of output would be 1 less than that of input edit_group.
+    Arg: a list of edit_group
+    Return: a list of integers
+    '''
+    n_edit = len(edit_group)
+    dists = [0] * (n_edit - 1)
+
+    for i in range(n_edit - 1):
+        dist = edit_group[i + 1].start - edit_group[i].end
+        dists[i] = dist
+
+    return dists


### PR DESCRIPTION
## Intro
Four cases are handled in bian. They are `str2str`,  `list2list`,  `str2list`, `list2str`. 
Four scripts have common functions: apply, inverse
Note that `str2list`, `list2str` do not have function inverse.

## Usage 
- apply: returns transformed str or tokens
```python
from uttut.pipeline.bian import str2str, str2lst
# str -> str
transformed_str = str2str.apply(input_str, edit_group)
# str -> list
tokens = str2lst.apply(input_str, edit_group, span_group)
```
- inverse: returns inverse edit_group (and inverse span_group)
```python
from uttut.pipeline.bian import str2str
# str -> str
inverse_edit_group = str2str.inverse(input_str, edit_group)
# str -> list
edit_group, span_group = str2lst.inverse(input_str, edit_group, span_group)
```

## Other
`str2list` has two extra functions: gen_edit_group, gen_span_group. 
By comparing input string and input tokens, these functions record the transformation using EditGroup and SpanGroup, respectively. 
