### PR TITLE
Add checkpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,16 +38,18 @@ Let's create a Pipe to preprocess a Datum with English utterance.
 >>> p.add('EngTokenizer')  # word-level (ref: BERT)
 >>> p.add('AddSosEos')
 >>> p.add_checkpoint()
->>> p.add('Pad')
+>>> p.add('Pad', {'maxlen': 5})
 >>> p.add(
     'Token2Index',
     {
-        '<sos>': 0, '<eos>': 1,  # for  AddSosEos
-        '<unk>': 2, '<pad>': 3,  # for Pad
-        '_int_': 4,  # for IntTokenWithSpace
-        '_float_': 5,  # for FloatTokenWithSpace
-        'I': 6,
-        'apples': 7,
+       'token2index': {
+            '<sos>': 0, '<eos>': 1,  # for  AddSosEos
+            '<unk>': 2, '<pad>': 3,  # for Pad
+            '_int_': 4,  # for IntTokenWithSpace
+            '_float_': 5,  # for FloatTokenWithSpace
+            'I': 6,
+            'apples': 7,
+        },
     },
 )
 
@@ -55,7 +57,7 @@ Let's create a Pipe to preprocess a Datum with English utterance.
 >>> datum = Datum(
     utterance='I like apples.',
     intents=[Intent(label=1), Intent(label=2)],
-    entities=[Entity(start=7, end=12, value='apples', label=7)],
+    entities=[Entity(start=7, end=13, value='apples', label=7)],
 )
 >>> output_indices, intent_labels, entity_labels, realigner, intermediate = p.transform(datum)
 >>> output_indices
@@ -64,7 +66,7 @@ Let's create a Pipe to preprocess a Datum with English utterance.
 [1, 2]
 >>> entity_labels
 [0, 0, 0, 7, 0, 0, 0]
->>> intermediate.get()
+>>> intermediate.get_from_checkpoint()
 (["<sos>", "I", "like", "apples", "<eos>"], [0, 0, 0, 7, 0]) 
 
 >>> realigner(entity_labels)

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ Let's create a Pipe to preprocess a Datum with English utterance.
 >>> p.add('MergeWhiteSpaceCharacters')
 >>> p.add('StripWhiteSpaceCharacters')
 >>> p.add('EngTokenizer')  # word-level (ref: BERT)
->>> p.add('AddSosEos')
->>> p.add_checkpoint()
+>>> p.add('AddSosEos', out='result_of_add_sos_eos')
 >>> p.add('Pad', {'maxlen': 5})
 >>> p.add(
     'Token2Index',
@@ -66,7 +65,7 @@ Let's create a Pipe to preprocess a Datum with English utterance.
 [1, 2]
 >>> entity_labels
 [0, 0, 0, 7, 0, 0, 0]
->>> intermediate.get_from_checkpoint()
+>>> intermediate.get_from_checkpoint('result_of_add_sos_eos')
 (["<sos>", "I", "like", "apples", "<eos>"], [0, 0, 0, 7, 0]) 
 
 >>> realigner(entity_labels)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Let's create a Pipe to preprocess a Datum with English utterance.
 >>> p.add('MergeWhiteSpaceCharacters')
 >>> p.add('StripWhiteSpaceCharacters')
 >>> p.add('EngTokenizer')  # word-level (ref: BERT)
->>> p.add('AddSosEos', out='result_of_add_sos_eos')
+>>> p.add('AddSosEos', checkpoint='result_of_add_sos_eos')
 >>> p.add('Pad', {'maxlen': 5})
 >>> p.add(
     'Token2Index',

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Let's create a Pipe to preprocess a Datum with English utterance.
 >>> p.add('StripWhiteSpaceCharacters')
 >>> p.add('EngTokenizer')  # word-level (ref: BERT)
 >>> p.add('AddSosEos')
+>>> p.add_checkpoint()
 >>> p.add('Pad')
 >>> p.add(
     'Token2Index',
@@ -56,13 +57,15 @@ Let's create a Pipe to preprocess a Datum with English utterance.
     intents=[Intent(label=1), Intent(label=2)],
     entities=[Entity(start=7, end=12, value='apples', label=7)],
 )
->>> output_indices, intent_labels, entity_labels, realigner = p.transform(datum)
+>>> output_indices, intent_labels, entity_labels, realigner, intermediate = p.transform(datum)
 >>> output_indices
 [0, 6, 2, 7, 1, 3, 3]
 >>> intent_labels
 [1, 2]
 >>> entity_labels
 [0, 0, 0, 7, 0, 0, 0]
+>>> intermediate.get()
+(["<sos>", "I", "like", "apples", "<eos>"], [0, 0, 0, 7, 0]) 
 
 >>> realigner(entity_labels)
 [0, 0, 0, 0, 0, 0, 0, 7, 7, 7, 7, 7, 7, 0] 

--- a/uttut/pipeline/intermediate.py
+++ b/uttut/pipeline/intermediate.py
@@ -3,19 +3,56 @@ from typing import List
 
 class Intermediate:
 
+    """Collect intermediate products when Pipe run transformation
+
+    attributes:
+        collection (list): store input intermediates
+        checkpoints (ints): indices of intermediates for query
+
+    """
+
     def __init__(self, checkpoints: List[int]):
         self.collection: list
         self.collection = []
         self.checkpoints = checkpoints
 
     def add(self, intermediate):
+        """Append intermediate into self.collection
+
+        Arg:
+            intermediate: object to be stored in self.collection
+
+        """
         self.collection.append(intermediate)
 
     def get(self, index: int = 0):
+        """Query intermediate in collection according to input index
+
+        Arg:
+            index (int)
+
+        Raise:
+            IndexError: list index out of range
+            if input index >= len(self.checkpoints) or
+            self.checkpoints(index) >= len(self.collection)
+
+        """
         if len(self.checkpoints) == 0:
             return []
         ck_index = self.checkpoints[index]
         return self.collection[ck_index]
 
-    def __getitem__(self, index: int):
-        return self.collection[index]
+    def __getitem__(self, key):
+        """Query intermediates by index or slice
+
+        Arg:
+            key (int or slice)
+
+        Return:
+            intermediates (list)
+
+        Raise:
+            IndexError: list index out of range if input index >= len(self.collection)
+
+        """
+        return self.collection[key]

--- a/uttut/pipeline/intermediate.py
+++ b/uttut/pipeline/intermediate.py
@@ -12,8 +12,7 @@ class Intermediate:
     """
 
     def __init__(self, checkpoints: List[int]):
-        self.collection: list
-        self.collection = []
+        self.collection: list = []
         self.checkpoints = checkpoints
 
     def add(self, intermediate):
@@ -25,7 +24,7 @@ class Intermediate:
         """
         self.collection.append(intermediate)
 
-    def get(self, index: int = 0):
+    def get_from_checkpoint(self, index: int = 0):
         """Query intermediate in collection according to input index
 
         Arg:

--- a/uttut/pipeline/intermediate.py
+++ b/uttut/pipeline/intermediate.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Dict
 
 
 class Intermediate:
@@ -7,42 +7,41 @@ class Intermediate:
 
     attributes:
         collection (list): store input intermediates
-        checkpoints (ints): indices of intermediates for query
+        checkpoints (dict): (key, value) = (name, index)
 
     """
 
-    def __init__(self, checkpoints: List[int]):
-        self.collection: list = []
-        self.checkpoints = checkpoints
+    def __init__(self, checkpoints: Dict[str, int]):
+        self._collection: list = []
+        self._checkpoints = checkpoints
 
     def add(self, intermediate):
-        """Append intermediate into self.collection
+        """Append intermediate into self._collection
 
         Arg:
             intermediate: object to be stored in self.collection
 
         """
-        self.collection.append(intermediate)
+        self._collection.append(intermediate)
 
-    def get_from_checkpoint(self, index: int = 0):
-        """Query intermediate in collection according to input index
+    def get_from_checkpoint(self, name: str):
+        """Retrieve intermediate in collection according to name of checkpoint
 
         Arg:
-            index (int)
+            name (str): name of checkpoint
 
         Raise:
-            IndexError: list index out of range
-            if input index >= len(self.checkpoints) or
-            self.checkpoints(index) >= len(self.collection)
+            KeyError if name is not in self._checkpoints
+            IndexError if self._checkpoints[name] >= len(self._collection)
 
         """
-        if len(self.checkpoints) == 0:
-            return []
-        ck_index = self.checkpoints[index]
-        return self.collection[ck_index]
+        if name not in self._checkpoints:
+            raise KeyError(f"{name} is not found.")
+        ck_index = self._checkpoints[name]
+        return self._collection[ck_index]
 
     def __getitem__(self, key):
-        """Query intermediates by index or slice
+        """Retrieve intermediates by index or slice
 
         Arg:
             key (int or slice)
@@ -54,4 +53,4 @@ class Intermediate:
             IndexError: list index out of range if input index >= len(self.collection)
 
         """
-        return self.collection[key]
+        return self._collection[key]

--- a/uttut/pipeline/intermediate.py
+++ b/uttut/pipeline/intermediate.py
@@ -1,0 +1,21 @@
+from typing import List
+
+
+class Intermediate:
+
+    def __init__(self, checkpoints: List[int]):
+        self.collection: list
+        self.collection = []
+        self.checkpoints = checkpoints
+
+    def add(self, intermediate):
+        self.collection.append(intermediate)
+
+    def get(self, index: int = 0):
+        if len(self.checkpoints) == 0:
+            return []
+        ck_index = self.checkpoints[index]
+        return self.collection[ck_index]
+
+    def __getitem__(self, index: int):
+        return self.collection[index]

--- a/uttut/pipeline/pipe.py
+++ b/uttut/pipeline/pipe.py
@@ -6,6 +6,7 @@ from uttut.elements import Datum
 
 from .ops.base import Realigner
 from .step import Step
+from .intermediate import Intermediate
 from .ops import op_factory as default_factory
 from .utils import unpack_datum
 
@@ -19,6 +20,8 @@ class Pipe:
         self.operator_factory = operator_factory
         if self.operator_factory is None:
             self.operator_factory = default_factory
+
+        self.checkpoints = []
 
     def add(self, op_name: str, op_kwargs=None):
         """Add steps based on the operation name.
@@ -45,6 +48,9 @@ class Pipe:
         self._push_step(step)
         self._push_step_info(op_name, op_kwargs)
 
+    def add_checkpoint(self):
+        self.checkpoints.append(len(self._steps))
+
     def _validate_steps(self, step: Step):
         if len(self._steps) > 0:
             target_type = self._steps[-1].output_type
@@ -69,7 +75,8 @@ class Pipe:
         same_op_factory = self.operator_factory == other.operator_factory
         same_steps = self._steps == other._steps
         same_step_info = self._step_info == other._step_info
-        return same_op_factory and same_steps and same_step_info
+        same_checkpoints = self.checkpoints == other.checkpoints
+        return same_op_factory and same_steps and same_step_info and same_checkpoints
 
     def transform(self, datum: Datum):
         """Process data based on Steps(Ops).
@@ -84,31 +91,41 @@ class Pipe:
             intent_labels (ints):
             entity_labels (ints):
             realigners: list of Realigners
+            intermediate: an instance of Intermediate
 
         """
-        input_sequence, intent_labels, entity_labels = unpack_datum(datum)
-
+        intermediate = Intermediate(self.checkpoints)
         realigners = RealignerSequence()
+
+        input_sequence, intent_labels, entity_labels = unpack_datum(datum)
+        intermediate.add((input_sequence, entity_labels))
         for step in self._steps:
             input_sequence, entity_labels, realigner = step.transform(input_sequence, entity_labels)
             realigners.add(realigner)
-        return input_sequence, intent_labels, entity_labels, realigners
+            intermediate.add((input_sequence, entity_labels))
+
+        return input_sequence, intent_labels, entity_labels, realigners, intermediate
 
     def serialize(self) -> str:
-        return json.dumps(self._step_info)
+        to_serialize = {
+            'steps': self._step_info,
+            'checkpoints': self.checkpoints,
+        }
+        return json.dumps(to_serialize)
 
     @classmethod
     def deserialize(cls, serialized_str: str, operator_factory=None) -> 'Pipe':
         pipe = cls(operator_factory)
-
-        step_infos = json.loads(serialized_str)
-
+        pipe_bundle = json.loads(serialized_str)
         # restore steps
+        step_infos = pipe_bundle['steps']
         for step_info in step_infos:
             pipe.add(
                 op_name=step_info['op_name'],
                 op_kwargs=step_info['op_kwargs'],
             )
+        # restore checkpoints
+        pipe.checkpoints = pipe_bundle['checkpoints']
         return pipe
 
 

--- a/uttut/pipeline/pipe.py
+++ b/uttut/pipeline/pipe.py
@@ -22,7 +22,7 @@ class Pipe:
         if self.operator_factory is None:
             self.operator_factory = default_factory
 
-    def add(self, op_name: str, op_kwargs=None, out=None):
+    def add(self, op_name: str, op_kwargs=None, checkpoint=None):
         """Add steps based on the operation name.
 
         This method creates a step, which has an op. The op
@@ -31,10 +31,10 @@ class Pipe:
         Args:
             op_name (str): the name of operator
             op_kwargs (dict): the corresponding of keyword arguments
-            out (str): the name of checkpoint
+            checkpoint (str): the name of checkpoint
 
         Raises:
-            KeyError if out is duplicated
+            KeyError if the input checkpoint has existed in self._checkpoints
 
         """
         if op_kwargs is None:
@@ -47,7 +47,7 @@ class Pipe:
 
         self._push_step(step)
         self._push_step_info(op_name, op_kwargs)
-        self._push_checkpoint(out)
+        self._push_checkpoint(checkpoint)
 
     def _validate_steps(self, step: Step):
         if len(self._steps) > 0:
@@ -94,7 +94,7 @@ class Pipe:
             output_sequence: transfromed sequence
             intent_labels (ints):
             entity_labels (ints):
-            realigners: list of Realigners
+            realigners: an instance of RealignerSequence
             intermediate: an instance of Intermediate
 
         """

--- a/uttut/pipeline/tests/test_intermediate.py
+++ b/uttut/pipeline/tests/test_intermediate.py
@@ -7,7 +7,7 @@ def _transform(input_lst, index):
 
 
 def test_all():
-    intm = Intermediate([1, 3])
+    intm = Intermediate({'1': 1, '3': 3})
     input_lst = [0]
     expected_record = []
     for i in range(10):
@@ -15,5 +15,5 @@ def test_all():
         intm.add(input_lst)
         expected_record.append(input_lst.copy())
     assert expected_record == intm[:]
-    assert expected_record[1] == intm.get_from_checkpoint()
-    assert expected_record[3] == intm.get_from_checkpoint(1)
+    assert expected_record[1] == intm.get_from_checkpoint('1')
+    assert expected_record[3] == intm.get_from_checkpoint('3')

--- a/uttut/pipeline/tests/test_intermediate.py
+++ b/uttut/pipeline/tests/test_intermediate.py
@@ -15,5 +15,5 @@ def test_all():
         intm.add(input_lst)
         expected_record.append(input_lst.copy())
     assert expected_record == intm[:]
-    assert expected_record[1] == intm.get()
-    assert expected_record[3] == intm.get(1)
+    assert expected_record[1] == intm.get_from_checkpoint()
+    assert expected_record[3] == intm.get_from_checkpoint(1)

--- a/uttut/pipeline/tests/test_intermediate.py
+++ b/uttut/pipeline/tests/test_intermediate.py
@@ -1,0 +1,19 @@
+from ..intermediate import Intermediate
+
+
+def _transform(input_lst, index):
+    output = input_lst + [index]
+    return output
+
+
+def test_all():
+    intm = Intermediate([1, 3])
+    input_lst = [0]
+    expected_record = []
+    for i in range(10):
+        input_lst = _transform(input_lst, i)
+        intm.add(input_lst)
+        expected_record.append(input_lst.copy())
+    assert expected_record == intm[:]
+    assert expected_record[1] == intm.get()
+    assert expected_record[3] == intm.get(1)

--- a/uttut/pipeline/tests/test_pipe.py
+++ b/uttut/pipeline/tests/test_pipe.py
@@ -60,7 +60,7 @@ def test_transform(fake_pipe, dummy_datum):
     assert output_seq == ['1', '2', '3']
     assert intent_labels == [1]
     assert entity_labels == [1, 2, 3]
-    assert [] == intermediate.get()
+    assert [] == intermediate.get_from_checkpoint()
     assert [('123', [1, 2, 3]), ('123', [1, 2, 3]),
             (['1', '2', '3'], [1, 2, 3]), (['1', '2', '3'], [1, 2, 3])] == intermediate[:]
 
@@ -75,8 +75,8 @@ def test_transform_with_checkpoints(fake_pipe_with_checkpoints, dummy_datum):
     assert output_seq == ['1', '2', '3']
     assert intent_labels == [1]
     assert entity_labels == [1, 2, 3]
-    assert ('123', [1, 2, 3]) == intermediate.get()
-    assert (['1', '2', '3'], [1, 2, 3]) == intermediate.get(1)
+    assert ('123', [1, 2, 3]) == intermediate.get_from_checkpoint()
+    assert (['1', '2', '3'], [1, 2, 3]) == intermediate.get_from_checkpoint(1)
     assert [('123', [1, 2, 3]), ('123', [1, 2, 3]),
             (['1', '2', '3'], [1, 2, 3]), (['1', '2', '3'], [1, 2, 3])] == intermediate[:]
 

--- a/uttut/pipeline/tests/test_pipe.py
+++ b/uttut/pipeline/tests/test_pipe.py
@@ -18,9 +18,9 @@ def fake_pipe():
 @pytest.fixture
 def fake_pipe_with_checkpoints():
     p_custom = Pipe(mock_factory)
-    p_custom.add('Str2Str', {'1': 1}, out='1')
+    p_custom.add('Str2Str', {'1': 1}, checkpoint='1')
     p_custom.add('Str2Lst', {})
-    p_custom.add('Lst2Lst', {}, out='2')
+    p_custom.add('Lst2Lst', {}, checkpoint='2')
     return p_custom
 
 
@@ -53,15 +53,15 @@ def test_pipe_has_invalid_op():
 
 def test_pipe_has_duplicated_checkpoints():
     p = Pipe(mock_factory)
-    p.add('Str2Str', out='1')
+    p.add('Str2Str', checkpoint='1')
     with pytest.raises(KeyError):
-        p.add('Str2Lst', out='1')
+        p.add('Str2Lst', checkpoint='1')
 
 
 def test_pipe_can_have_duplicated_ops():
     p = Pipe(mock_factory)
-    p.add('Str2Str', out='1')
-    p.add('Str2Str', out='2')
+    p.add('Str2Str', checkpoint='1')
+    p.add('Str2Str', checkpoint='2')
 
 
 def test_transform(fake_pipe, dummy_datum):

--- a/uttut/pipeline/tests/test_pipe.py
+++ b/uttut/pipeline/tests/test_pipe.py
@@ -9,10 +9,34 @@ from .mock_factory import mock_factory
 @pytest.fixture
 def fake_pipe():
     p_custom = Pipe(mock_factory)
-    p_custom.add('Str2Str', {})
+    p_custom.add('Str2Str', {'1': 1})
     p_custom.add('Str2Lst', {})
     p_custom.add('Lst2Lst', {})
     return p_custom
+
+
+@pytest.fixture
+def fake_pipe_with_checkpoints():
+    p_custom = Pipe(mock_factory)
+    p_custom.add('Str2Str', {'1': 1})
+    p_custom.add_checkpoint()
+    p_custom.add('Str2Lst', {})
+    p_custom.add('Lst2Lst', {})
+    p_custom.add_checkpoint()
+    return p_custom
+
+
+@pytest.fixture
+def dummy_datum():
+    return Datum(
+        utterance='123',
+        intents=[Intent(1)],
+        entities=[
+            Entity(label=1, start=0, end=1, value='1'),
+            Entity(label=2, start=1, end=2, value='2'),
+            Entity(label=3, start=2, end=3, value='3'),
+        ],
+    )
 
 
 def test_pipe_init_use_correct_factory():
@@ -29,31 +53,44 @@ def test_pipe_fails_to_add():
         p.add('Str2Str')
 
 
-def test_transform(fake_pipe):
-    datum = Datum(
-        utterance='123',
-        intents=[Intent(1)],
-        entities=[
-            Entity(label=1, start=0, end=1, value='1'),
-            Entity(label=2, start=1, end=2, value='2'),
-            Entity(label=3, start=2, end=3, value='3'),
-        ],
-    )
-    output_seq, intent_labels, entity_labels, realigner = fake_pipe.transform(datum)
+def test_transform(fake_pipe, dummy_datum):
+    output_seq, intent_labels, entity_labels, realigner, intermediate = fake_pipe.transform(
+        dummy_datum)
 
     assert output_seq == ['1', '2', '3']
     assert intent_labels == [1]
     assert entity_labels == [1, 2, 3]
+    assert [] == intermediate.get()
+    assert [('123', [1, 2, 3]), ('123', [1, 2, 3]),
+            (['1', '2', '3'], [1, 2, 3]), (['1', '2', '3'], [1, 2, 3])] == intermediate[:]
 
     output = realigner(entity_labels)
     assert output == [1, 2, 3]
 
 
-def test_serialization():
-    p_custom = Pipe(mock_factory)
-    p_custom.add('Str2Str', {'1': 1})
+def test_transform_with_checkpoints(fake_pipe_with_checkpoints, dummy_datum):
+    output = fake_pipe_with_checkpoints.transform(dummy_datum)
+    output_seq, intent_labels, entity_labels, realigner, intermediate = output
 
-    serialized_str = p_custom.serialize()
+    assert output_seq == ['1', '2', '3']
+    assert intent_labels == [1]
+    assert entity_labels == [1, 2, 3]
+    assert ('123', [1, 2, 3]) == intermediate.get()
+    assert (['1', '2', '3'], [1, 2, 3]) == intermediate.get(1)
+    assert [('123', [1, 2, 3]), ('123', [1, 2, 3]),
+            (['1', '2', '3'], [1, 2, 3]), (['1', '2', '3'], [1, 2, 3])] == intermediate[:]
+
+    output = realigner(entity_labels)
+    assert output == [1, 2, 3]
+
+
+def test_serialization(fake_pipe):
+    serialized_str = fake_pipe.serialize()
     o_pipe = Pipe.deserialize(serialized_str, mock_factory)
+    assert fake_pipe == o_pipe
 
-    assert p_custom == o_pipe
+
+def test_serialization_with_checkpoint(fake_pipe_with_checkpoints):
+    serialized_str = fake_pipe_with_checkpoints.serialize()
+    o_pipe = Pipe.deserialize(serialized_str, mock_factory)
+    assert fake_pipe_with_checkpoints == o_pipe


### PR DESCRIPTION
In this PR, `Pipe` has extra ability to collect intermediate result during transformation by using `add_checkpoint` and  `Intermediate`.
1. `add_checkpoint`:
This is an extra method of `Pipe` created in this PR. It appends the index of step into `self._checkpoints` to memorize which outcome of step is required to be stored.
For example,  if you create a Pipe as follow, you means to keep the outcome of operator2 and operator3 during transformation.
```python
p = Pipe()
p.add('op1_name', {})
p.add('op2_name', {}, checkpoint='0')
p.add('op3_name', {}, checkpoint='1')
p.add('op4_name', {})
```

2. `Intermediate`:
`Intermediate` is a class for collecting all outcomes of `Step`(or `Operator`) during transformation of `Pipe`. We involve `Intermediate` in the transformation process of `Pipe`. So,  `Pipe` will return an instance of `Intermediate` when `transform` is called. 
Take the above pipe as an example:
```python
>>> indices, intent_labels, entity_labels, realigner, intermediate = p.transform(datum)
>>> intermediate.get_from_checkpoint('0')
# return the result of Op2
>>> intermediate.get_from_checkpoint('1')
# return the result of Op3
>>> intermediate[0]
# return raw input
>>> intermediate[1]
# return the result of Op1  
```