### PR TITLE
faster operator

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -19,6 +19,7 @@ exclude_lines =
     ABC
     @abstractmethod
     @abstractclassmethod
+    pass
 
     # Don't complain if non-runnable code isn't run:
     if 0:

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ $ pip install uttut
 
 Let's create a Pipe to preprocess a Datum with English utterance.
 
+## Build a Pipe
+
 ```python
 >>> from uttut.pipeline.pipe import Pipe
 
@@ -51,26 +53,50 @@ Let's create a Pipe to preprocess a Datum with English utterance.
         },
     },
 )
+```
 
+## transform
+
+```python
 >>> from uttut.elements import Datum, Entity, Intent
 >>> datum = Datum(
     utterance='I like apples.',
     intents=[Intent(label=1), Intent(label=2)],
     entities=[Entity(start=7, end=13, value='apples', label=7)],
 )
->>> output_indices, intent_labels, entity_labels, realigner, intermediate = p.transform(datum)
+>>> output_indices, intent_labels, entity_labels, label_aligner, intermediate = p.transform(datum)
 >>> output_indices
 [0, 6, 2, 7, 1, 3, 3]
 >>> intent_labels
 [1, 2]
 >>> entity_labels
 [0, 0, 0, 7, 0, 0, 0]
+
+# intermediate
 >>> intermediate.get_from_checkpoint('result_of_add_sos_eos')
-(["<sos>", "I", "like", "apples", "<eos>"], [0, 0, 0, 7, 0]) 
+["<sos>", "I", "like", "apples", "<eos>"] 
 
->>> realigner(entity_labels)
-[0, 0, 0, 0, 0, 0, 0, 7, 7, 7, 7, 7, 7, 0] 
+# label_aligner
+>>> label_aligner.inverse_transform(entity_labels)
+[0, 0, 0, 0, 0, 0, 0, 7, 7, 7, 7, 7, 7, 0]
+```
 
+## transform sequence
+
+```python
+>>> output_sequence, label_aligner, intermediate = p.transform_sequence('I like apples.')
+>>> output_sequence
+[0, 6, 2, 7, 1, 3, 3]
+
+# label_aligner
+>>> label_aligner.transform([0, 0, 0, 0, 0, 0, 0, 7, 7, 7, 7, 7, 7, 0])
+[0, 0, 0, 7, 0, 0, 0]
+>>> label_aligner.inverse_transform([0, 0, 0, 7, 0, 0, 0])
+[0, 0, 0, 0, 0, 0, 0, 7, 7, 7, 7, 7, 7, 0]
+
+# intermediate
+>>> intermediate.get_from_checkpoint('result_of_add_sos_eos')
+["<sos>", "I", "like", "apples", "<eos>"]
 ```
 
 # Serialization

--- a/uttut/pipeline/edit/label_propagation.py
+++ b/uttut/pipeline/edit/label_propagation.py
@@ -10,6 +10,7 @@ def propagate_by_replacement_group(
         replacement_group: ReplacementGroup,
         transduce_func: Callable[[List[int], int], List[int]] = None,
     ) -> List[int]:
+
     '''Map the labels[fstart_i: fend_i] to output_labels[rstart_i: rend_i]
 
     Note that the length of replacement_group should be the same as

--- a/uttut/pipeline/ops/add_sos_eos.py
+++ b/uttut/pipeline/ops/add_sos_eos.py
@@ -70,19 +70,23 @@ class AddSosEos(Operator):
 
 class AddSosEosAligner(LabelAligner):
 
-    def _transform(self, labels):
-        return propagate_by_replacement_group(labels, self._forward_edit, self._forward_reduce_func)
+    def _transform(self, labels: List[int]) -> List[int]:
+        return propagate_by_replacement_group(
+            labels=labels,
+            replacement_group=self._forward_edit,
+            transduce_func=self._forward_transduce_func,
+        )
 
-    def _forward_reduce_func(self, labels: List[int], output_size: int) -> List[int]:
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_not_entity(labels=labels, output_size=output_size)
 
-    def _inverse_transform(self, labels):
+    def _inverse_transform(self, labels: List[int]) -> List[int]:
         inverse_replacement_group = lst2lst.inverse(self._input_sequence, self._forward_edit)
         return propagate_by_replacement_group(
             labels=labels,
             replacement_group=inverse_replacement_group,
-            transduce_func=self._backward_reduce_func,
+            transduce_func=self._backward_transduce_func,
         )
 
-    def _backward_reduce_func(self, labels: List[int], output_size: int) -> List[int]:
+    def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_not_entity(labels=labels, output_size=output_size)

--- a/uttut/pipeline/ops/add_sos_eos.py
+++ b/uttut/pipeline/ops/add_sos_eos.py
@@ -32,8 +32,7 @@ class AddSosEos(Operator):
             start_token: str = START_TOKEN,
             end_token: str = END_TOKEN,
         ):
-        super().__init__(input_type='list', output_type='list')
-        print('ohoh')
+        super().__init__(input_type=list, output_type=list)
         self.start_token = start_token
         self.end_token = end_token
 
@@ -42,7 +41,7 @@ class AddSosEos(Operator):
         same_end_token = self.end_token == other.end_token
         return same_start_token and same_end_token and super().__eq__(other)
 
-    def transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
+    def _transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = lst2lst.apply(input_sequence, forward_replacement_group)
 

--- a/uttut/pipeline/ops/add_sos_eos.py
+++ b/uttut/pipeline/ops/add_sos_eos.py
@@ -16,13 +16,14 @@ class AddSosEos(Operator):
     E.g.
     >>> from uttut.pipeline.ops.add_sos_eos import AddSosEos
     >>> op = AddSosEos()
-    >>> output_seq, output_labels, realigner = op.transform(
-        ['I', 'have', '10.7', 'dollars', '.'], [1, 2, 3, 4, 5])
+    >>> output_seq, label_aligner = op.transform(
+        ['I', 'have', '10.7', 'dollars', '.'])
+    >>> output_labels = label_aligner.transform([1, 2, 3, 4, 5])
     >>> output_seq
     ['<sos>', 'I', 'have', '10.7', 'dollars', '.', '<eos>']
     >>> output_labels
     [0, 1, 2, 3, 4, 5, 0]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 2, 3, 4, 5]
 
     """

--- a/uttut/pipeline/ops/add_whitespace_around_character.py
+++ b/uttut/pipeline/ops/add_whitespace_around_character.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple
 
-from .base import Operator, Realigner
+from .base import Operator, LabelAligner
 from .label_transducer import get_most_common_except_not_entity
 from ..edit.replacement import ReplacementGroup
 from ..edit import str2str
@@ -17,36 +17,17 @@ class AddWhitespaceAroundCharacter(Operator):
 
     def __init__(self):
         super().__init__(input_type=str, output_type=str)
-        self._realigner_class = AddWhitespaceAroundCharRealigner
 
-    def __eq__(self, other):
-        same_realigner_class = self._realigner_class == other._realigner_class
-        return same_realigner_class and super().__eq__(other)
-
-    def transform(  # type: ignore
-            self,
-            input_sequence: str,
-            labels: List[int],
-            state: dict = None,
-        ) -> Tuple[str, List[int], 'Realigner']:
-
+    def transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)
-        inverse_replacement_group = str2str.inverse(input_sequence, forward_replacement_group)
 
-        updated_labels = propagate_by_replacement_group(
-            labels=labels,
-            replacement_group=forward_replacement_group,
-            transduce_func=self._forward_transduce_func,
+        label_aligner = AddWhitespaceAroundCharAligner(
+            input_sequence=input_sequence,
+            edit=forward_replacement_group,
+            output_length=len(output_sequence),
         )
-
-        realigner = self._realigner_class(
-            edit=inverse_replacement_group,
-            input_length=len(output_sequence),
-            output_length=len(input_sequence),
-        )
-
-        return output_sequence, updated_labels, realigner
+        return output_sequence, label_aligner
 
     def _gen_forward_replacement_group(self, input_str: str) -> ReplacementGroup:
         replacement_group = ReplacementGroup()
@@ -63,20 +44,28 @@ class AddWhitespaceAroundCharacter(Operator):
         replacement_group.done()
         return replacement_group
 
-    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
-        assert len(labels) == 1
-        return [ENTITY_LABEL['NOT_ENTITY'], labels[0], ENTITY_LABEL['NOT_ENTITY']]
-
     def _is_valid_char(self, char: str) -> bool:
         raise NotImplementedError
 
 
-class AddWhitespaceAroundCharRealigner(Realigner):
+class AddWhitespaceAroundCharAligner(LabelAligner):
 
-    def _realign_labels(self, labels: List[int]) -> List[int]:
+    def _transform(self, labels: List[int]) -> ReplacementGroup:
         return propagate_by_replacement_group(
             labels=labels,
-            replacement_group=self._edit,
+            replacement_group=self._forward_edit,
+            transduce_func=self._forward_transduce_func,
+        )
+
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        assert len(labels) == 1
+        return [ENTITY_LABEL['NOT_ENTITY'], labels[0], ENTITY_LABEL['NOT_ENTITY']]
+
+    def _inverse_transform(self, labels):
+        inverse_replacement_group = str2str.inverse(self._input_sequence, self._forward_edit)
+        return propagate_by_replacement_group(
+            labels=labels,
+            replacement_group=inverse_replacement_group,
             transduce_func=self._backward_transduce_func,
         )
 

--- a/uttut/pipeline/ops/add_whitespace_around_character.py
+++ b/uttut/pipeline/ops/add_whitespace_around_character.py
@@ -18,7 +18,7 @@ class AddWhitespaceAroundCharacter(Operator):
     def __init__(self):
         super().__init__(input_type=str, output_type=str)
 
-    def transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
+    def _transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)
 

--- a/uttut/pipeline/ops/add_whitespace_around_cjk.py
+++ b/uttut/pipeline/ops/add_whitespace_around_cjk.py
@@ -9,19 +9,18 @@ class AddWhitespaceAroundCJK(AddWhitespaceAroundCharacter):
     E.g.
     >>> from uttut.pipeline.ops.add_whitespace_around_cjk import AddWhitespaceAroundCJK
     >>> op = AddWhitespaceAroundCJK()
-    >>> output_seq, output_labels, realigner = op.transform(
-        "GB亂入", [1, 1, 2, 3])
+    >>> output_seq, label_aligner = op.transform("GB亂入")
+    >>> output_labels = label_aligner.transform([1, 1, 2, 3])
     >>> output_seq
     "GB 亂  入 "
     >>> output_labels
     [1, 1, 0, 2, 0, 0, 3, 0]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 1, 2, 3]
 
     """
 
     def _is_valid_char(self, char: str) -> bool:
-
         """Check whether input char is the codepoint of a CJK character.
 
         This code is copied from Bert `tokenization.py`.

--- a/uttut/pipeline/ops/add_whitespace_around_punctuation.py
+++ b/uttut/pipeline/ops/add_whitespace_around_punctuation.py
@@ -12,19 +12,18 @@ class AddWhitespaceAroundPunctuation(AddWhitespaceAroundCharacter):
     >>> from uttut.pipeline.ops.add_whitespace_around_punctuation import (
         AddWhitespaceAroundPunctuation)
     >>> op = AddWhitespaceAroundPunctuation()
-    >>> output_seq, output_labels, realigner = op.transform(
-        "GB,薄餡亂入", [1, 1, 2, 3, 3, 4, 5])
+    >>> output_seq, label_aligner = op.transform("GB,薄餡亂入")
+    >>> output_labels = label_aligner.transform([1, 1, 2, 3, 3, 4, 5])
     >>> output_seq
     "GB , 薄餡亂入"
     >>> output_labels
     [1, 1, 0, 2, 0, 3, 3, 4, 5]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 1, 2, 3, 3, 4, 5]
 
     """
 
     def _is_valid_char(self, char: str) -> bool:
-
         """Check whether char is a punctuation character.
 
         This code is copied from Bert `tokenization.py`.

--- a/uttut/pipeline/ops/base.py
+++ b/uttut/pipeline/ops/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Tuple, List, Any
+from typing import List, Tuple, Any
 
 
 class Operator(ABC):
@@ -19,11 +19,9 @@ class Operator(ABC):
         self._output_type = output_type
 
     def __eq__(self, other):
-        if not isinstance(other, self.__class__):
-            return False
-        same_input_type = self._input_type == other._input_type
-        same_output_type = self._output_type == other._output_type
-        return same_input_type and same_output_type
+        self_attrs = (self._input_type, self._output_type)
+        other_attrs = (other._input_type, other._output_type)
+        return self_attrs == other_attrs
 
     @property
     def input_type(self):
@@ -34,13 +32,7 @@ class Operator(ABC):
         return self._output_type
 
     @abstractmethod
-    def transform(
-            self,
-            input_sequence,
-            labels: List[int],
-            state: dict = None,
-        ) -> Tuple[Any, List[int], 'Realigner']:
-
+    def transform(self, input_sequence) -> Tuple[Any, 'LabelAligner']:
         """Transform input_sequence and label
 
         Transform input_sequence to certain form which meets the output_type
@@ -48,63 +40,48 @@ class Operator(ABC):
 
         Args:
             input_sequence (input_type): utterance or tokens
-            labels (ints): has same length of input_sequence
-            state (dict): data dependent information (output of fit)
 
         Returns:
-            output (output_type): the transformed result
-            labels (ints): has same length as output of transfrom
-            realigner (obj): an instance of Realigner
+            output_sequence (output_type): the transformed result
+            label_aligner (obj): an instance of LabelAligner
 
         """
         pass
 
 
-class Realigner(ABC):
+class LabelAligner(ABC):
 
-    """Base class for label Realigner
-
-    Sub-classes should implement `_realign_labels`
-
-    Attributes:
-        input_length (int): the length of sequence transformed by Operator
-        output_length (int): the length of input sequence passed to Operator.transform
-        edit: process of transformation documented by `edit` structure.
-
-    """
-
-    def __init__(self, edit, input_length: int, output_length: int):
-        self._edit = edit
-        self._input_length = input_length
+    def __init__(self, input_sequence, edit, output_length):
+        self._input_length = len(input_sequence)
         self._output_length = output_length
 
-    def __call__(self, labels: List[int]) -> List[int]:
+        self._input_sequence = input_sequence
+        self._forward_edit = edit
 
-        """Realign model labels to original input
-
-        Args:
-            labels (ints): has same length as output of Operator.transfrom
-
-        Raise:
-            ValueError if length of labels is not matched.
-
-        Return:
-            labels (ints): has same length as input of Operator.transform
-
-        """
+    def transform(self, labels: List[int]):
         self._validate_input(labels)
-        output_labels = self._realign_labels(labels)
+        output_labels = self._transform(labels)
         self._validate_output(output_labels)
         return output_labels
 
-    def _validate_input(self, labels: List[int]):
+    def inverse_transform(self, labels: List[int]):
+        self._validate_output(labels)
+        output_labels = self._inverse_transform(labels)
+        self._validate_input(output_labels)
+        return output_labels
+
+    def _validate_input(self, labels):
         if len(labels) != self._input_length:
             raise ValueError('Invalid input labels')
 
-    def _validate_output(self, labels: List[int]):
+    def _validate_output(self, labels):
         if len(labels) != self._output_length:
             raise ValueError('Invalid output labels')
 
     @abstractmethod
-    def _realign_labels(self, labels: List[int]) -> List[int]:
+    def _transform(self, labels):
+        pass
+
+    @abstractmethod
+    def _inverse_transform(self, labels):
         pass

--- a/uttut/pipeline/ops/base.py
+++ b/uttut/pipeline/ops/base.py
@@ -31,9 +31,9 @@ class Operator(ABC):
     def output_type(self):
         return self._output_type
 
-    @abstractmethod
     def transform(self, input_sequence) -> Tuple[Any, 'LabelAligner']:
-        """Transform input_sequence and label
+
+        """Transform input_sequence
 
         Transform input_sequence to certain form which meets the output_type
         and updates labels if necessary.
@@ -46,6 +46,22 @@ class Operator(ABC):
             label_aligner (obj): an instance of LabelAligner
 
         """
+
+        self._validate_input(input_sequence)
+        output_sequence, label_aligner = self._transform(input_sequence)
+        self._validate_output(output_sequence)
+        return output_sequence, label_aligner
+
+    def _validate_input(self, input_sequence):
+        if not isinstance(input_sequence, self.input_type):
+            raise TypeError('Invalid input type')
+
+    def _validate_output(self, output_sequence):
+        if not isinstance(output_sequence, self.output_type):
+            raise TypeError('Invalid output type')
+
+    @abstractmethod
+    def _transform(self, input_sequence) -> Tuple[Any, 'LabelAligner']:
         pass
 
 

--- a/uttut/pipeline/ops/char_tokenizer.py
+++ b/uttut/pipeline/ops/char_tokenizer.py
@@ -6,6 +6,22 @@ from .label_transducer import get_most_common_except_not_entity
 
 class CharTokenizer(Tokenizer):
 
+    """Character level tokenizer
+
+    E.g.
+    >>> from uttut.pipeline.ops.char_tokenizer import CharTokenizer
+    >>> op = CharTokenizer()
+    >>> output_seq, label_aligner = op.transform("a b")
+    >>> output_labels = label_aligner.transform([1, 2, 3])
+    >>> output_seq
+    ["a", "b"]
+    >>> output_labels
+    [1, 3]
+    >>> label_aligner.inverse_transform(output_labels)
+    [1, 0, 3]
+
+    """
+
     def __init__(self):
         super().__init__(label_aligner_class=CharTokenizerAligner)
 

--- a/uttut/pipeline/ops/char_tokenizer.py
+++ b/uttut/pipeline/ops/char_tokenizer.py
@@ -1,7 +1,6 @@
 from typing import List
 
 from .tokenizer import Tokenizer, TokenizerAligner
-from .label_transducer import get_most_common_except_not_entity
 
 
 class CharTokenizer(Tokenizer):
@@ -32,7 +31,7 @@ class CharTokenizer(Tokenizer):
 class CharTokenizerAligner(TokenizerAligner):
 
     def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
-        return get_most_common_except_not_entity(labels, output_size)
+        pass
 
     def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
-        return get_most_common_except_not_entity(labels, output_size)
+        pass

--- a/uttut/pipeline/ops/char_tokenizer.py
+++ b/uttut/pipeline/ops/char_tokenizer.py
@@ -1,19 +1,22 @@
 from typing import List
 
-from .base import Realigner
-from .tokenizer import Tokenizer
+from .tokenizer import Tokenizer, TokenizerAligner
+from .label_transducer import get_most_common_except_not_entity
 
 
 class CharTokenizer(Tokenizer):
 
     def __init__(self):
-        super().__init__(realigner_class=CharTokenizerRealigner)
+        super().__init__(label_aligner_class=CharTokenizerAligner)
 
     def _tokenize(self, input_str: str) -> List[str]:
         return list(input_str)
 
 
-class CharTokenizerRealigner(Realigner):
+class CharTokenizerAligner(TokenizerAligner):
 
-    def _realign_labels(self, labels: List[int]):
-        return labels
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        return get_most_common_except_not_entity(labels, output_size)
+
+    def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        return get_most_common_except_not_entity(labels, output_size)

--- a/uttut/pipeline/ops/eng_tokenizer.py
+++ b/uttut/pipeline/ops/eng_tokenizer.py
@@ -2,7 +2,7 @@ from typing import List
 
 import unicodedata
 
-from .tokenizer import Tokenizer, TokenizerRealigner
+from .tokenizer import Tokenizer, TokenizerAligner
 from .label_transducer import get_most_common_except_not_entity
 
 
@@ -27,7 +27,7 @@ class EngTokenizer(Tokenizer):
     """
 
     def __init__(self):
-        super().__init__(realigner_class=EngTokenizerRealigner)
+        super().__init__(label_aligner_class=EngTokenizerAligner)
 
     def _tokenize(self, input_str: str) -> List[str]:
         orig_tokens = whitespace_tokenize(input_str)
@@ -100,7 +100,10 @@ def _is_punctuation(char):
     return False
 
 
-class EngTokenizerRealigner(TokenizerRealigner):
+class EngTokenizerAligner(TokenizerAligner):
+
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        return get_most_common_except_not_entity(labels, output_size)
 
     def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_most_common_except_not_entity(labels, output_size)

--- a/uttut/pipeline/ops/eng_tokenizer.py
+++ b/uttut/pipeline/ops/eng_tokenizer.py
@@ -16,12 +16,13 @@ class EngTokenizer(Tokenizer):
     E.g.
     >>> from uttut.pipeline.ops.eng_tokenizer import EngTokenizer
     >>> op = EngTokenizer()
-    >>> output_seq, output_labels, realigner = op.transform("a b", [1, 2, 3])
+    >>> output_seq, label_aligner = op.transform("a b")
+    >>> output_labels = label_aligner.transform([1, 2, 3])
     >>> output_seq
     ["a", "b"]
     >>> output_labels
     [1, 3]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 0, 3]
 
     """

--- a/uttut/pipeline/ops/float_token.py
+++ b/uttut/pipeline/ops/float_token.py
@@ -1,9 +1,7 @@
-from typing import List
 import re
 
 from .tokens import FLOAT_TOKEN
-from .int_token import IntTokenRealigner
-from .label_transducer import get_most_common
+from .int_token import IntTokenAligner
 from .pattern_to_token import PatternRecognizer
 
 
@@ -29,10 +27,7 @@ class FloatToken(PatternRecognizer):
     TOKEN = FLOAT_TOKEN
 
     def __init__(self):
-        super().__init__(realigner_class=IntTokenRealigner)
-
-    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
-        return get_most_common(labels=labels, output_size=output_size)
+        super().__init__(label_aligner_class=IntTokenAligner)
 
     def _gen_forward_replacement_group(self, input_str: str):  # type: ignore
         return super()._gen_forward_replacement_group(

--- a/uttut/pipeline/ops/float_token.py
+++ b/uttut/pipeline/ops/float_token.py
@@ -6,6 +6,7 @@ from .pattern_to_token import PatternRecognizer
 
 
 class FloatToken(PatternRecognizer):
+
     """
     Recognize float (ex: 12.3, 1.7) in the input string
     and replace them with FLOAT_TOKEN (_float_)
@@ -13,12 +14,13 @@ class FloatToken(PatternRecognizer):
     E.g.
     >>> from uttut.pipeline.ops.float_token import FloatToken
     >>> op = FloatToken()
-    >>> output_seq, output_labels, realigner = op.transform("10.7", [1, 1, 1, 1])
+    >>> output_seq, label_aligner = op.transform("10.7")
+    >>> output_labels = label_aligner.transform([1, 1, 1, 1])
     >>> output_seq
     "_float_"
     >>> output_labels
     [1, 1, 1, 1, 1, 1, 1]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 1, 1, 1]
 
     """

--- a/uttut/pipeline/ops/float_token_with_space.py
+++ b/uttut/pipeline/ops/float_token_with_space.py
@@ -18,12 +18,13 @@ class FloatTokenWithSpace(PatternRecognizer):
     E.g.
     >>> from uttut.pipeline.ops.float_token_with_space import FloatTokenWithSpace
     >>> op = FloatTokenWithSpace()
-    >>> output_seq, output_labels, realigner = op.transform("10.7", [1, 1, 1, 1])
+    >>> output_seq, label_aligner = op.transform("10.7")
+    >>> output_labels = label_aligner.transform([1, 1, 1, 1])
     >>> output_seq
     " _float_ "
     >>> output_labels
     [0, 1, 1, 1, 1, 1, 1, 1, 0]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 1, 1, 1]
 
     """

--- a/uttut/pipeline/ops/int_token.py
+++ b/uttut/pipeline/ops/int_token.py
@@ -15,12 +15,13 @@ class IntToken(PatternRecognizer):
     E.g.
     >>> from uttut.pipeline.ops.int_token import IntToken
     >>> op = IntToken()
-    >>> output_seq, output_labels, realigner = op.transform("10", [1, 1])
+    >>> output_seq, realigner = op.transform("10")
+    >>> output_labels = label_aligner.transform([1, 1])
     >>> output_seq
     "_int_"
     >>> output_labels
     [1, 1, 1, 1, 1]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 1]
 
     """

--- a/uttut/pipeline/ops/int_token.py
+++ b/uttut/pipeline/ops/int_token.py
@@ -3,7 +3,7 @@ from typing import List
 import re
 
 from .tokens import INT_TOKEN
-from .pattern_to_token import PatternRecognizer, PatternRecognizerRealigner
+from .pattern_to_token import PatternRecognizer, PatternRecognizerAligner
 from .label_transducer import get_most_common, get_most_common_except_not_entity
 
 
@@ -29,10 +29,7 @@ class IntToken(PatternRecognizer):
     TOKEN = INT_TOKEN
 
     def __init__(self):
-        super().__init__(realigner_class=IntTokenRealigner)
-
-    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
-        return get_most_common(labels=labels, output_size=output_size)
+        super().__init__(label_aligner_class=IntTokenAligner)
 
     def _gen_forward_replacement_group(self, input_str: str):  # type: ignore
         return super()._gen_forward_replacement_group(
@@ -41,7 +38,10 @@ class IntToken(PatternRecognizer):
         )
 
 
-class IntTokenRealigner(PatternRecognizerRealigner):
+class IntTokenAligner(PatternRecognizerAligner):
+
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        return get_most_common(labels=labels, output_size=output_size)
 
     def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_most_common_except_not_entity(labels, output_size)

--- a/uttut/pipeline/ops/int_token_with_space.py
+++ b/uttut/pipeline/ops/int_token_with_space.py
@@ -18,12 +18,13 @@ class IntTokenWithSpace(PatternRecognizer):
     E.g.
     >>> from uttut.pipeline.ops.int_token_with_space import IntTokenWithSpace
     >>> op = IntTokenWithSpace()
-    >>> output_seq, output_labels, realigner = op.transform("10", [1, 1])
+    >>> output_seq, label_aligner = op.transform("10")
+    >>> output_labels = label_aligner.transform([1, 1])
     >>> output_seq
     " _int_ "
     >>> output_labels
     [0, 1, 1, 1, 1, 1, 0]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 1]
 
     """

--- a/uttut/pipeline/ops/int_token_with_space.py
+++ b/uttut/pipeline/ops/int_token_with_space.py
@@ -4,21 +4,13 @@ import re
 from collections import Counter
 
 from .tokens import INT_TOKEN_WITH_SPACE
-from .pattern_to_token import PatternRecognizer, PatternRecognizerRealigner
+from .pattern_to_token import PatternRecognizer, PatternRecognizerAligner
 from .label_transducer import get_most_common_except_not_entity
 from uttut import ENTITY_LABEL
 
 
-def _forward_transduce_func(labels: List[int], output_size: int, token: str) -> List[int]:
-    counter = Counter(labels)
-    common_label = counter.most_common()[0][0]
-    token_len = len(token) - 2
-    output_label = [ENTITY_LABEL['NOT_ENTITY']] + \
-        [common_label] * token_len + [ENTITY_LABEL['NOT_ENTITY']]
-    return output_label
-
-
 class IntTokenWithSpace(PatternRecognizer):
+
     """
     Recognize integer (ex: 12, 10000) in the input string
     and replace them with INT_TOKEN_WTIH_SPACE ( _int_ )
@@ -40,10 +32,7 @@ class IntTokenWithSpace(PatternRecognizer):
     TOKEN = INT_TOKEN_WITH_SPACE
 
     def __init__(self):
-        super().__init__(realigner_class=IntTokenWithSpaceRealigner)
-
-    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
-        return _forward_transduce_func(labels=labels, output_size=output_size, token=self.TOKEN)
+        super().__init__(label_aligner_class=IntTokenWithSpaceAligner)
 
     def _gen_forward_replacement_group(self, input_str: str):  # type: ignore
         return super()._gen_forward_replacement_group(
@@ -52,7 +41,16 @@ class IntTokenWithSpace(PatternRecognizer):
         )
 
 
-class IntTokenWithSpaceRealigner(PatternRecognizerRealigner):
+class IntTokenWithSpaceAligner(PatternRecognizerAligner):
+
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        token = IntTokenWithSpace.TOKEN
+        counter = Counter(labels)
+        common_label = counter.most_common()[0][0]
+        token_len = len(token) - 2
+        output_label = [ENTITY_LABEL['NOT_ENTITY']] + \
+            [common_label] * token_len + [ENTITY_LABEL['NOT_ENTITY']]
+        return output_label
 
     def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_most_common_except_not_entity(labels, output_size)

--- a/uttut/pipeline/ops/lowercase.py
+++ b/uttut/pipeline/ops/lowercase.py
@@ -8,18 +8,20 @@ from ..edit import str2str
 
 
 class Lowercase(Operator):
+
     """
     Recognize uppercase characters and convert them into lowercase characters
 
     E.g.
     >>> from uttut.pipeline.ops.lowercase import Lowercase
     >>> op = Lowercase()
-    >>> output_seq, output_labels, realigner = op.transform("ABc", [1, 2, 3])
+    >>> output_seq, label_aligner = op.transform("ABc")
+    >>> output_labels = label_aligner.transform([1, 2, 3])
     >>> output_seq
     "abc"
     >>> output_labels
     [1, 2, 3]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 2, 3]
 
     """
@@ -30,7 +32,6 @@ class Lowercase(Operator):
         super().__init__(input_type=str, output_type=str)
 
     def _transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
-
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)
         assert len(input_sequence) == len(output_sequence)
@@ -43,7 +44,6 @@ class Lowercase(Operator):
         return output_sequence, label_aligner
 
     def _gen_forward_replacement_group(self, input_str: str) -> ReplacementGroup:
-
         shift = 0
         replacement_group = ReplacementGroup()
 

--- a/uttut/pipeline/ops/lowercase.py
+++ b/uttut/pipeline/ops/lowercase.py
@@ -29,7 +29,7 @@ class Lowercase(Operator):
     def __init__(self):
         super().__init__(input_type=str, output_type=str)
 
-    def transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
+    def _transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
 
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)

--- a/uttut/pipeline/ops/lowercase.py
+++ b/uttut/pipeline/ops/lowercase.py
@@ -2,7 +2,7 @@ from typing import List, Tuple
 
 import re
 
-from .base import Operator, Realigner
+from .base import Operator, LabelAligner
 from ..edit.replacement import ReplacementGroup
 from ..edit import str2str
 
@@ -28,38 +28,21 @@ class Lowercase(Operator):
 
     def __init__(self):
         super().__init__(input_type=str, output_type=str)
-        self._realigner_class = LowercaseRealigner
 
-    def __eq__(self, other):
-        same_realigner_class = self._realigner_class == other._realigner_class
-        return same_realigner_class and super().__eq__(other)
-
-    def transform(  # type: ignore
-            self,
-            input_sequence: str,
-            labels: List[int],
-            state: dict = None,
-        ) -> Tuple[str, List[int], 'Realigner']:
+    def transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
 
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)
         assert len(input_sequence) == len(output_sequence)
 
-        inverse_replacement_group = str2str.inverse(input_sequence, forward_replacement_group)
-
-        realigner = self._realigner_class(
-            edit=inverse_replacement_group,
-            input_length=len(output_sequence),
-            output_length=len(input_sequence),
+        label_aligner = LowercaseAligner(
+            input_sequence=input_sequence,
+            edit=forward_replacement_group,
+            output_length=len(output_sequence),
         )
+        return output_sequence, label_aligner
 
-        return output_sequence, labels, realigner
-
-    def _gen_forward_replacement_group(
-            self,
-            input_str: str,
-            annotation: str = None,
-        ) -> ReplacementGroup:
+    def _gen_forward_replacement_group(self, input_str: str) -> ReplacementGroup:
 
         shift = 0
         replacement_group = ReplacementGroup()
@@ -73,14 +56,17 @@ class Lowercase(Operator):
                 start=match.start(),
                 end=match.end(),
                 new_value=matched_str.lower(),
-                annotation=annotation,
+                annotation='lowercase',
             )
             shift = match.end()
         replacement_group.done()
         return replacement_group
 
 
-class LowercaseRealigner(Realigner):
+class LowercaseAligner(LabelAligner):
 
-    def _realign_labels(self, labels: List[int]) -> List[int]:
+    def _transform(self, labels: List[int]) -> List[int]:
+        return labels
+
+    def _inverse_transform(self, labels: List[int]) -> List[int]:
         return labels

--- a/uttut/pipeline/ops/merge_whitespace_characters.py
+++ b/uttut/pipeline/ops/merge_whitespace_characters.py
@@ -15,12 +15,13 @@ class MergeWhiteSpaceCharacters(PatternRecognizer):
     E.g.
     >>> from uttut.pipeline.ops.merge_whitespace_characters import MergeWhiteSpaceCharacters
     >>> op = MergeWhiteSpaceCharacters()
-    >>> output_seq, output_labels, realigner = op.transform("\n\n  \t\t", [1, 1, 1, 1, 1, 1])
+    >>> output_seq, label_aligner = op.transform("\n\n  \t\t")
+    >>> output_labels = label_aligner.transform([1, 1, 1, 1, 1, 1])
     >>> output_seq
     " "
     >>> output_labels
     [0]
-    >>> realigner(output_labels)
+    >>> label_aligner(output_labels)
     [0, 0, 0, 0, 0, 0]
 
     """

--- a/uttut/pipeline/ops/merge_whitespace_characters.py
+++ b/uttut/pipeline/ops/merge_whitespace_characters.py
@@ -2,7 +2,7 @@ from typing import List
 
 import re
 
-from .pattern_to_token import PatternRecognizer, PatternRecognizerRealigner
+from .pattern_to_token import PatternRecognizer, PatternRecognizerAligner
 from .label_transducer import get_most_common
 
 
@@ -29,13 +29,13 @@ class MergeWhiteSpaceCharacters(PatternRecognizer):
     TOKEN = " "
 
     def __init__(self):
-        super().__init__(realigner_class=MergeWhiteSpaceCharactersRealigner)
+        super().__init__(label_aligner_class=MergeWhiteSpaceCharactersAligner)
+
+
+class MergeWhiteSpaceCharactersAligner(PatternRecognizerAligner):
 
     def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_most_common(labels=labels, output_size=output_size)
-
-
-class MergeWhiteSpaceCharactersRealigner(PatternRecognizerRealigner):
 
     def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_most_common(labels=labels, output_size=output_size)

--- a/uttut/pipeline/ops/pad.py
+++ b/uttut/pipeline/ops/pad.py
@@ -17,12 +17,13 @@ class Pad(Operator):
     E.g.
     >>> from uttut.pipeline.ops.pad import Pad
     >>> op = Pad(5)
-    >>> output_seq, output_labels, realigner = op.transform(['apple'], [1])
+    >>> output_seq, label_aligner = op.transform(['apple'])
+    >>> output_labels = label_aligner.transform([1])
     >>> output_seq
     ['apple', '<pad>', '<pad>', '<pad>', '<pad>']
     >>> output_labels
     [1, 0, 0, 0, 0]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1]
 
     """

--- a/uttut/pipeline/ops/pad.py
+++ b/uttut/pipeline/ops/pad.py
@@ -37,7 +37,7 @@ class Pad(Operator):
         same_maxlen = self.maxlen == other.maxlen
         return same_pad_token and same_maxlen and super().__eq__(other)
 
-    def transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
+    def _transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
 
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = lst2lst.apply(input_sequence, forward_replacement_group)

--- a/uttut/pipeline/ops/pad.py
+++ b/uttut/pipeline/ops/pad.py
@@ -1,7 +1,8 @@
 from typing import List, Tuple
 
-from .base import Operator, Realigner
+from .base import Operator, LabelAligner
 from .tokens import PAD_TOKEN
+from .label_transducer import get_not_entity
 
 from ..edit import lst2lst
 from ..edit.replacement import ReplacementGroup
@@ -26,11 +27,7 @@ class Pad(Operator):
 
     """
 
-    def __init__(
-            self,
-            maxlen: int,
-            pad_token: str = PAD_TOKEN,
-        ):
+    def __init__(self, maxlen: int, pad_token: str = PAD_TOKEN):
         super().__init__(input_type=list, output_type=list)
         self.pad_token = pad_token
         self.maxlen = maxlen
@@ -40,33 +37,20 @@ class Pad(Operator):
         same_maxlen = self.maxlen == other.maxlen
         return same_pad_token and same_maxlen and super().__eq__(other)
 
-    def transform(  # type: ignore
-            self,
-            input_sequence: List[str],
-            labels: List[int],
-            state: dict = None,
-        ) -> Tuple[List[str], List[int], 'Realigner']:
+    def transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
 
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = lst2lst.apply(input_sequence, forward_replacement_group)
-        inverse_replacement_group = lst2lst.inverse(input_sequence, forward_replacement_group)
 
-        updated_labels = propagate_by_replacement_group(
-            labels, forward_replacement_group, self._forward_reduce_func)
-
-        realigner = PadRealigner(
-            edit=inverse_replacement_group,
-            input_length=len(output_sequence),
-            output_length=len(input_sequence),
+        label_aligner = PadAligner(
+            input_sequence=input_sequence,
+            edit=forward_replacement_group,
+            output_length=len(output_sequence),
         )
 
-        return output_sequence, updated_labels, realigner
+        return output_sequence, label_aligner
 
-    def _gen_forward_replacement_group(
-            self,
-            input_lst: List[str],
-            annotation: str = None,
-        ) -> ReplacementGroup:
+    def _gen_forward_replacement_group(self, input_lst: List[str]) -> ReplacementGroup:
 
         seqlen = len(input_lst)
         diff = self.maxlen - seqlen
@@ -83,14 +67,26 @@ class Pad(Operator):
             )
         return replacement_group
 
-    def _forward_reduce_func(self, labels: List[int], output_size: int) -> List[int]:
-        return [0] * output_size
 
+class PadAligner(LabelAligner):
 
-class PadRealigner(Realigner):
+    def _transform(self, labels: List[int]) -> List[int]:
+        return propagate_by_replacement_group(
+            labels=labels,
+            replacement_group=self._forward_edit,
+            transduce_func=self._forward_transduce_func,
+        )
 
-    def _realign_labels(self, labels: List[int]) -> List[int]:
-        return propagate_by_replacement_group(labels, self._edit, self._backward_reduce_func)
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        return get_not_entity(labels, output_size)
 
-    def _backward_reduce_func(self, labels: List[int], output_size: int) -> List[int]:
-        return [0] * output_size
+    def _inverse_transform(self, labels: List[int]) -> List[int]:
+        inverse_replacement_group = lst2lst.inverse(self._input_sequence, self._forward_edit)
+        return propagate_by_replacement_group(
+            labels=labels,
+            replacement_group=inverse_replacement_group,
+            transduce_func=self._backward_transduce_func,
+        )
+
+    def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        return get_not_entity(labels, output_size)

--- a/uttut/pipeline/ops/pattern_to_token.py
+++ b/uttut/pipeline/ops/pattern_to_token.py
@@ -23,7 +23,7 @@ class PatternRecognizer(Operator):
         same_label_aligner_class = self._label_aligner_class == other._label_aligner_class
         return same_label_aligner_class and super().__eq__(other)
 
-    def transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
+    def _transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
 
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)

--- a/uttut/pipeline/ops/pattern_to_token.py
+++ b/uttut/pipeline/ops/pattern_to_token.py
@@ -24,7 +24,6 @@ class PatternRecognizer(Operator):
         return same_label_aligner_class and super().__eq__(other)
 
     def _transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
-
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)
 
@@ -40,7 +39,6 @@ class PatternRecognizer(Operator):
             input_str: str,
             annotation: str = None,
         ) -> ReplacementGroup:
-
         shift = 0
         replacement_group = ReplacementGroup()
 

--- a/uttut/pipeline/ops/span_subwords.py
+++ b/uttut/pipeline/ops/span_subwords.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple, Dict
 
 from .tokens import UNK_TOKEN
-from .base import Operator, Realigner
+from .base import Operator, LabelAligner
 from .label_transducer import get_most_common, get_most_common_except_not_entity
 from ..edit import lst2lst
 from ..edit.replacement import ReplacementGroup
@@ -16,14 +16,13 @@ class SpanSubwords(Operator):
             unk_token: str = UNK_TOKEN,
             maxlen_per_token: int = 200,
         ):
-
         """
         Span each element in input_sequence to several subwords according to the input vocabulary.
 
         If the element or part of element is not found in vocabulary,
         the unk_token would be returned.
 
-        ## Requirement: All elements in input_sequence should not contain
+        # Requirement: All elements in input_sequence should not contain
                         whitespaces and accent tokens.
 
         This class is almost the same as WordPieceTokenizer in BERT.
@@ -46,7 +45,6 @@ class SpanSubwords(Operator):
         self.vocab = vocab
         self.unk_token = unk_token
         self.maxlen_per_token = maxlen_per_token
-        self._realigner_class = WordPieceRealigner
 
     def __eq__(self, other):
         same_vocab = self.vocab == other.vocab
@@ -54,31 +52,21 @@ class SpanSubwords(Operator):
         same_maxlen_per_token = self.maxlen_per_token == other.maxlen_per_token
         return same_vocab and same_unk_token and same_maxlen_per_token and super().__eq__(other)
 
-    def transform(  # type: ignore
-            self,
-            input_sequence: List[str],
-            labels: List[int],
-        ) -> Tuple[List[str], List[int], 'Realigner']:
-
+    def transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
         """
-        ## Requirement: All elements in input_sequence should not contain
+        # Requirement: All elements in input_sequence should not contain
                         whitespaces and accent tokens.
         """
 
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = lst2lst.apply(input_sequence, forward_replacement_group)
-        inverse_replacement_group = lst2lst.inverse(input_sequence, forward_replacement_group)
 
-        updated_labels = propagate_by_replacement_group(
-            labels, forward_replacement_group, self._forward_reduce_func)
-
-        realigner = self._realigner_class(
-            edit=inverse_replacement_group,
-            input_length=len(output_sequence),
-            output_length=len(input_sequence),
+        label_aligner = SpanSubwordsAligner(
+            input_sequence=input_sequence,
+            edit=forward_replacement_group,
+            output_length=len(output_sequence),
         )
-
-        return output_sequence, updated_labels, realigner
+        return output_sequence, label_aligner
 
     def _gen_forward_replacement_group(self, input_lst: List[str]) -> ReplacementGroup:
 
@@ -101,17 +89,29 @@ class SpanSubwords(Operator):
 
         return replacement_group
 
-    def _forward_reduce_func(self, labels: List[int], output_size: int):
+
+class SpanSubwordsAligner(LabelAligner):
+
+    def _transform(self, labels: List[int]) -> List[int]:
+        return propagate_by_replacement_group(
+            labels=labels,
+            replacement_group=self._forward_edit,
+            transduce_func=self._forward_transduce_func,
+        )
+
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_most_common(labels, output_size)
 
-
-class WordPieceRealigner(Realigner):
+    def _inverse_transform(self, labels: List[int]) -> List[int]:
+        inverse_replacement_group = lst2lst.inverse(self._input_sequence, self._forward_edit)
+        return propagate_by_replacement_group(
+            labels=labels,
+            replacement_group=inverse_replacement_group,
+            transduce_func=self._backward_transduce_func,
+        )
 
     def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_most_common_except_not_entity(labels, output_size)
-
-    def _realign_labels(self, labels: List[int]) -> List[int]:
-        return propagate_by_replacement_group(labels, self._edit, self._backward_transduce_func)
 
 
 def span_subwords(
@@ -120,7 +120,6 @@ def span_subwords(
         vocab: Dict[str, int],
         max_input_chars_per_word: int,
     ) -> List[str]:
-
     """
     Tokenize a word into several subwords.
 

--- a/uttut/pipeline/ops/span_subwords.py
+++ b/uttut/pipeline/ops/span_subwords.py
@@ -52,7 +52,7 @@ class SpanSubwords(Operator):
         same_maxlen_per_token = self.maxlen_per_token == other.maxlen_per_token
         return same_vocab and same_unk_token and same_maxlen_per_token and super().__eq__(other)
 
-    def transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
+    def _transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
         """
         # Requirement: All elements in input_sequence should not contain
                         whitespaces and accent tokens.

--- a/uttut/pipeline/ops/span_subwords.py
+++ b/uttut/pipeline/ops/span_subwords.py
@@ -31,12 +31,13 @@ class SpanSubwords(Operator):
         E.g.
         >>> from uttut.pipeline.ops.span_subwords import SpanSubwords
         >>> op = SpanSubwords(vocab={"I": 0, "apple": 1, "##s": 2}, unk='<unk>', maxlen_per_token=5)
-        >>> output_seq, output_labels, realigner = op.transform(["I", "like", "apples"], [1, 2, 3])
+        >>> output_seq, output_labels, realigner = op.transform(["I", "like", "apples"])
+        >>> output_labels = label_aligner.transform([1, 2, 3])
         >>> output_seq
         ["I", "<unk>", "apple", "##s"]
         >>> output_labels
         [1, 2, 3, 3]
-        >>> realigner(output_labels)
+        >>> label_aligner.inverse_transform(output_labels)
         [1, 2, 3]
 
         """
@@ -57,7 +58,6 @@ class SpanSubwords(Operator):
         # Requirement: All elements in input_sequence should not contain
                         whitespaces and accent tokens.
         """
-
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = lst2lst.apply(input_sequence, forward_replacement_group)
 
@@ -69,7 +69,6 @@ class SpanSubwords(Operator):
         return output_sequence, label_aligner
 
     def _gen_forward_replacement_group(self, input_lst: List[str]) -> ReplacementGroup:
-
         replacement_group = ReplacementGroup()
         for i, token in enumerate(input_lst):
             subtokens = span_subwords(

--- a/uttut/pipeline/ops/strip_accent_token.py
+++ b/uttut/pipeline/ops/strip_accent_token.py
@@ -1,7 +1,7 @@
 from typing import List, Tuple
 import unicodedata
 
-from .base import Operator, Realigner
+from .base import Operator, LabelAligner
 from .label_transducer import get_most_common_except_not_entity
 from ..edit.replacement import ReplacementGroup
 from ..edit import str2str
@@ -29,36 +29,18 @@ class StripAccentToken(Operator):
 
     def __init__(self):
         super().__init__(input_type=str, output_type=str)
-        self._realigner_class = StripAccentTokenRealigner
 
-    def __eq__(self, other):
-        same_realigner_class = self._realigner_class == other._realigner_class
-        return same_realigner_class and super().__eq__(other)
-
-    def transform(  # type: ignore
-            self,
-            input_sequence: str,
-            labels: List[int],
-            state: dict = None,
-        ) -> Tuple[str, List[int], 'Realigner']:
+    def transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
 
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)
-        inverse_replacement_group = str2str.inverse(input_sequence, forward_replacement_group)
 
-        updated_labels = propagate_by_replacement_group(
-            labels=labels,
-            replacement_group=forward_replacement_group,
-            transduce_func=self._forward_transduce_func,
+        label_aligner = StripAccentTokenAligner(
+            input_sequence=input_sequence,
+            edit=forward_replacement_group,
+            output_length=len(output_sequence),
         )
-
-        realigner = self._realigner_class(
-            edit=inverse_replacement_group,
-            input_length=len(output_sequence),
-            output_length=len(input_sequence),
-        )
-
-        return output_sequence, updated_labels, realigner
+        return output_sequence, label_aligner
 
     def _gen_forward_replacement_group(self, input_str: str) -> ReplacementGroup:
         replacement_group = ReplacementGroup()
@@ -77,16 +59,24 @@ class StripAccentToken(Operator):
         replacement_group.done()
         return replacement_group
 
+
+class StripAccentTokenAligner(LabelAligner):
+
+    def _transform(self, labels: List[int]) -> List[int]:
+        return propagate_by_replacement_group(
+            labels=labels,
+            replacement_group=self._forward_edit,
+            transduce_func=self._forward_transduce_func,
+        )
+
     def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_most_common_except_not_entity(labels, output_size)
 
-
-class StripAccentTokenRealigner(Realigner):
-
-    def _realign_labels(self, labels: List[int]) -> List[int]:
+    def _inverse_transform(self, labels: List[int]) -> List[int]:
+        inverse_replacement_group = str2str.inverse(self._input_sequence, self._forward_edit)
         return propagate_by_replacement_group(
             labels=labels,
-            replacement_group=self._edit,
+            replacement_group=inverse_replacement_group,
             transduce_func=self._backward_transduce_func,
         )
 

--- a/uttut/pipeline/ops/strip_accent_token.py
+++ b/uttut/pipeline/ops/strip_accent_token.py
@@ -16,13 +16,13 @@ class StripAccentToken(Operator):
     E.g.
     >>> from uttut.pipeline.ops.strip_accent_token import StripAccentToken
     >>> op = StripAccentToken()
-    >>> output_seq, output_labels, realigner = op.transform(
-        u"H\u00E9llo", [1, 2, 3, 4, 5])
+    >>> output_seq, label_aligner = op.transform(u"H\u00E9llo")
+    >>> output_labels = label_aligner.transform([1, 2, 3, 4, 5])
     >>> output_seq
     "Hello"
     >>> output_labels
     [1, 2, 3, 4, 5]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 2, 3, 4, 5]
 
     """
@@ -31,7 +31,6 @@ class StripAccentToken(Operator):
         super().__init__(input_type=str, output_type=str)
 
     def _transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
-
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)
 
@@ -44,7 +43,6 @@ class StripAccentToken(Operator):
 
     def _gen_forward_replacement_group(self, input_str: str) -> ReplacementGroup:
         replacement_group = ReplacementGroup()
-
         output_str = _strip_accents(input_str)
         assert len(input_str) == len(output_str)
 

--- a/uttut/pipeline/ops/strip_accent_token.py
+++ b/uttut/pipeline/ops/strip_accent_token.py
@@ -30,7 +30,7 @@ class StripAccentToken(Operator):
     def __init__(self):
         super().__init__(input_type=str, output_type=str)
 
-    def transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
+    def _transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
 
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)

--- a/uttut/pipeline/ops/strip_whitespace_characters.py
+++ b/uttut/pipeline/ops/strip_whitespace_characters.py
@@ -15,12 +15,13 @@ class StripWhiteSpaceCharacters(PatternRecognizer):
     E.g.
     >>> from uttut.pipeline.ops.strip_whitespace_characters import StripWhiteSpaceCharacters
     >>> op = StripWhiteSpaceCharacters()
-    >>> output_seq, output_labels, realigner = op.transform(" a\n", [1, 2, 3])
+    >>> output_seq, label_aligner = op.transform(" a\n")
+    >>> output_labels = label_aligner.transform([1, 2, 3])
     >>> output_seq
     "a"
     >>> output_labels
     [2]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [0, 2, 0]
 
     """

--- a/uttut/pipeline/ops/strip_whitespace_characters.py
+++ b/uttut/pipeline/ops/strip_whitespace_characters.py
@@ -2,7 +2,7 @@ from typing import List
 
 import re
 
-from .pattern_to_token import PatternRecognizer, PatternRecognizerRealigner
+from .pattern_to_token import PatternRecognizer, PatternRecognizerAligner
 from .label_transducer import get_not_entity
 
 
@@ -29,10 +29,7 @@ class StripWhiteSpaceCharacters(PatternRecognizer):
     TOKEN = ""
 
     def __init__(self):
-        super().__init__(realigner_class=StripWhiteSpaceCharactersRealigner)
-
-    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
-        return get_not_entity(labels=labels, output_size=output_size)
+        super().__init__(label_aligner_class=StripWhiteSpaceCharactersAligner)
 
     def _gen_forward_replacement_group(self, input_str: str):  # type: ignore
         return super()._gen_forward_replacement_group(
@@ -41,7 +38,10 @@ class StripWhiteSpaceCharacters(PatternRecognizer):
         )
 
 
-class StripWhiteSpaceCharactersRealigner(PatternRecognizerRealigner):
+class StripWhiteSpaceCharactersAligner(PatternRecognizerAligner):
+
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        return get_not_entity(labels=labels, output_size=output_size)
 
     def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_not_entity(labels=labels, output_size=output_size)

--- a/uttut/pipeline/ops/tests/common_tests.py
+++ b/uttut/pipeline/ops/tests/common_tests.py
@@ -42,13 +42,23 @@ def common_test(test_cases):
         assert len(output_sequence) == len(output_labels)
 
     def test_transform(input_sequence, input_labels, output_sequence, output_labels, op):
-        output = op.transform(input_sequence, input_labels)
+        output = op.transform(input_sequence)
         assert output_sequence == output[0]
-        assert output_labels == output[1]
 
-    def test_realign_labels(input_sequence, input_labels, output_sequence, output_labels, op):
-        _, _, realigner = op.transform(input_sequence, input_labels)
-        output = realigner(output_labels)
+    def test_transform_labels(input_sequence, input_labels, output_sequence, output_labels, op):
+        _, label_aligner = op.transform(input_sequence)
+        output = label_aligner.transform(input_labels)
+        assert output_labels == output
+
+    def test_inverse_transform_labels(
+            input_sequence,
+            input_labels,
+            output_sequence,
+            output_labels,
+            op,
+        ):
+        _, label_aligner = op.transform(input_sequence)
+        output = label_aligner.inverse_transform(output_labels)
         assert input_labels == output
 
     argstr = "input_sequence,input_labels,output_sequence,output_labels"

--- a/uttut/pipeline/ops/tests/test_add_sos_eos.py
+++ b/uttut/pipeline/ops/tests/test_add_sos_eos.py
@@ -24,6 +24,15 @@ funcs = common_test(test_cases)
 update_locals(locals(), funcs)
 
 
+# def test_all(op):
+#     output_sequence, label_aligner = op.transform(['alvin', '喜歡', '吃', '榴槤'])
+#     assert output_sequence == ['<sos>', 'alvin', '喜歡', '吃', '榴槤', '<eos>']
+#     output_labels = label_aligner.align_labels([1, 2, 3, 4])
+#     assert output_labels == [0, 1, 2, 3, 4, 0]
+#     re_labels = label_aligner.realign_labels([0, 1, 2, 3, 4, 0])
+#     assert re_labels == [1, 2, 3, 4]
+
+
 def test_equal(op):
     assert op == AddSosEos()
 

--- a/uttut/pipeline/ops/tests/test_eng_tokenizer.py
+++ b/uttut/pipeline/ops/tests/test_eng_tokenizer.py
@@ -70,11 +70,13 @@ def test_invertible_cases(
         expected_realigned_labels,
         op,
     ):
-    output_seq, output_labels, realigner = op.transform(input_str, input_labels)
+    output_seq, label_aligner = op.transform(input_str)
     assert expected_output_seq == output_seq
+
+    output_labels = label_aligner.transform(input_labels)
     assert expected_output_labels == output_labels
 
-    realigned_labels = realigner(output_labels)
+    realigned_labels = label_aligner.inverse_transform(expected_output_labels)
     assert expected_realigned_labels == realigned_labels
 
 

--- a/uttut/pipeline/ops/tests/test_pad.py
+++ b/uttut/pipeline/ops/tests/test_pad.py
@@ -34,15 +34,16 @@ update_locals(locals(), funcs)
 
 def test_longer_case(op):
     # labels are not invertible
-    output_seq, output_labels, realigner = op.transform(
+    output_seq, label_aligner = op.transform(
         ['alvin', '喜歡', '吃', '榴槤', '和', '蟲', '!'],
-        [1, 2, 3, 4, 5, 6, 7],
     )
     assert ['alvin', '喜歡', '吃', '榴槤', '和'] == output_seq
+
+    output_labels = label_aligner.transform([1, 2, 3, 4, 5, 6, 7])
     assert [1, 2, 3, 4, 5] == output_labels
 
-    output = realigner([1, 2, 3, 4, 5])
-    assert output == [1, 2, 3, 4, 5, 0, 0]
+    output = label_aligner.inverse_transform(output_labels)
+    assert [1, 2, 3, 4, 5, 0, 0] == output
 
 
 def test_equal(op):

--- a/uttut/pipeline/ops/tests/test_strip_whitespace_characters.py
+++ b/uttut/pipeline/ops/tests/test_strip_whitespace_characters.py
@@ -54,14 +54,13 @@ update_locals(locals(), funcs)
 
 def test_all_whitespaces(op):
     # labels are not invertible
-    output_seq, output_labels, realigner = op.transform(
-        "  \n\n\t\t",
-        [1, 2, 3, 4, 5, 6],
-    )
+    output_seq, label_aligner = op.transform("  \n\n\t\t")
     assert "" == output_seq
+
+    output_labels = label_aligner.transform([1, 2, 3, 4, 5, 6])
     assert [] == output_labels
 
-    output = realigner([])
+    output = label_aligner.inverse_transform([])
     assert output == [0, 0, 0, 0, 0, 0]
 
 

--- a/uttut/pipeline/ops/token_to_index.py
+++ b/uttut/pipeline/ops/token_to_index.py
@@ -17,13 +17,13 @@ class Token2Index(Operator):
     E.g.
     >>> from uttut.pipeline.ops.token_to_index import Token2Index
     >>> op = Token2Index({'I': 1, 'like': 2, 'apples': 3})
-    >>> output_seq, output_labels, realigner = op.transform(
-        ['I', 'like', 'apples'], [3, 4, 5])
+    >>> output_seq, label_aligner = op.transform(['I', 'like', 'apples'])
+    >>> output_labels = label_aligner.transform([3, 4, 5])
     >>> output_seq
     [1, 2, 3]
     >>> output_labels
     [3, 4, 5]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [3, 4, 5]
 
     """

--- a/uttut/pipeline/ops/token_to_index.py
+++ b/uttut/pipeline/ops/token_to_index.py
@@ -52,7 +52,7 @@ class Token2Index(Operator):
         if unk_token not in token2index:
             raise KeyError(f"token2index should have token {unk_token}")
 
-    def transform(self, input_sequence: List[str]) -> Tuple[List[int], 'LabelAligner']:
+    def _transform(self, input_sequence: List[str]) -> Tuple[List[int], 'LabelAligner']:
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = lst2lst.apply(input_sequence, forward_replacement_group)
 

--- a/uttut/pipeline/ops/token_to_index.py
+++ b/uttut/pipeline/ops/token_to_index.py
@@ -1,6 +1,6 @@
 from typing import List, Tuple, Dict
 
-from .base import Operator, Realigner
+from .base import Operator, LabelAligner
 from .tokens import UNK_TOKEN
 
 from ..edit import lst2lst
@@ -28,11 +28,7 @@ class Token2Index(Operator):
 
     """
 
-    def __init__(
-            self,
-            token2index: Dict[str, int],
-            unk_token: str = UNK_TOKEN,
-        ):
+    def __init__(self, token2index: Dict[str, int], unk_token: str = UNK_TOKEN):
         super().__init__(input_type=list, output_type=list)
         self._validate_token2index(token2index, unk_token)
         self.token2index = token2index
@@ -56,32 +52,22 @@ class Token2Index(Operator):
         if unk_token not in token2index:
             raise KeyError(f"token2index should have token {unk_token}")
 
-    def transform(
-            self,
-            input_sequence: List[str],
-            labels: List[int],
-            state: dict = None,
-        ) -> Tuple[List[int], List[int], 'Realigner']:
-
+    def transform(self, input_sequence: List[str]) -> Tuple[List[int], 'LabelAligner']:
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = lst2lst.apply(input_sequence, forward_replacement_group)
-        inverse_replacement_group = lst2lst.inverse(input_sequence, forward_replacement_group)
 
-        realigner = Token2IndexRealigner(
-            edit=inverse_replacement_group,
-            input_length=len(output_sequence),
-            output_length=len(input_sequence),
+        label_aligner = Token2IndexAligner(
+            input_sequence=input_sequence,
+            edit=forward_replacement_group,
+            output_length=len(output_sequence),
         )
-
-        return output_sequence, labels, realigner
+        return output_sequence, label_aligner
 
     def _gen_forward_replacement_group(
             self,
             input_lst: List[str],
-            annotation: str = None,
         ) -> ReplacementGroup:
 
-        index: int
         replacement_group = ReplacementGroup()
         for idx, token in enumerate(input_lst):
             if token in self.token2index:
@@ -98,7 +84,10 @@ class Token2Index(Operator):
         return replacement_group
 
 
-class Token2IndexRealigner(Realigner):
+class Token2IndexAligner(LabelAligner):
 
-    def _realign_labels(self, labels: List[int]) -> List[int]:
+    def _transform(self, labels: List[int]):
+        return labels
+
+    def _inverse_transform(self, labels):
         return labels

--- a/uttut/pipeline/ops/tokenizer.py
+++ b/uttut/pipeline/ops/tokenizer.py
@@ -48,7 +48,7 @@ class Tokenizer(Operator):
 
 class TokenizerAligner(LabelAligner):
 
-    def _transform(self, labels: List[int]):
+    def _transform(self, labels: List[int]) -> List[int]:
         output_labels = propagate_by_replacement_group(
             labels=labels,
             replacement_group=self._forward_edit['replacement_group'],
@@ -60,7 +60,7 @@ class TokenizerAligner(LabelAligner):
     def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         raise NotImplementedError
 
-    def _inverse_transform(self, labels):
+    def _inverse_transform(self, labels: List[int]) -> List[int]:
         inverse_replacement_group = str2str.inverse(
             self._input_sequence, self._forward_edit['replacement_group'])
         output_labels = expand_by_span_group(

--- a/uttut/pipeline/ops/tokenizer.py
+++ b/uttut/pipeline/ops/tokenizer.py
@@ -24,7 +24,6 @@ class Tokenizer(Operator):
         return same_label_aligner_class and super().__eq__(other)
 
     def _transform(self, input_sequence: str) -> Tuple[List[str], 'LabelAligner']:
-
         tokens = self._tokenize(input_sequence)
 
         # transform sequence

--- a/uttut/pipeline/ops/tokenizer.py
+++ b/uttut/pipeline/ops/tokenizer.py
@@ -58,7 +58,7 @@ class TokenizerAligner(LabelAligner):
         output_labels = reduce_by_span_group(output_labels, self._forward_edit['span_group'])
         return output_labels
 
-    def _forward_reduce_func(self, labels: List[int], output_size: int) -> List[int]:
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         raise NotImplementedError
 
     def _inverse_transform(self, labels):
@@ -75,5 +75,5 @@ class TokenizerAligner(LabelAligner):
         )
         return output_labels
 
-    def _backward_reduce_func(self, labels: List[int], output_size: int) -> List[int]:
+    def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         raise NotImplementedError

--- a/uttut/pipeline/ops/tokenizer.py
+++ b/uttut/pipeline/ops/tokenizer.py
@@ -7,7 +7,7 @@ from ..edit.label_propagation import (
     expand_by_span_group,
 )
 
-from .base import Operator, Realigner
+from .base import Operator, LabelAligner
 
 
 class Tokenizer(Operator):
@@ -15,58 +15,65 @@ class Tokenizer(Operator):
     Base class for Operators which tokenize text.
     """
 
-    def __init__(self, realigner_class):
+    def __init__(self, label_aligner_class):
         super().__init__(input_type=str, output_type=list)
-        self._realigner_class = realigner_class
+        self._label_aligner_class = label_aligner_class
 
     def __eq__(self, other):
-        same_realigner_class = self._realigner_class == other._realigner_class
-        return same_realigner_class and super().__eq__(other)
+        same_label_aligner_class = self._label_aligner_class == other._label_aligner_class
+        return same_label_aligner_class and super().__eq__(other)
 
-    def transform(  # type: ignore
-            self,
-            input_sequence: str,
-            labels: List[int],
-            state: dict = None,
-        ) -> Tuple[List[str], List[int], 'Realigner']:
+    def transform(self, input_sequence: str) -> Tuple[List[str], 'LabelAligner']:
 
         tokens = self._tokenize(input_sequence)
 
         # transform sequence
         forward_replacement_group = str2lst.gen_replacement_group(input_sequence, tokens)
         temp_str = str2str.apply(input_sequence, forward_replacement_group)
-        inverse_replacement_group = str2str.inverse(input_sequence, forward_replacement_group)
-
         span_group = str2lst.gen_span_group(temp_str, tokens)
 
-        # labels
-        output_labels = propagate_by_replacement_group(labels, forward_replacement_group)
-        output_labels = reduce_by_span_group(output_labels, span_group)
-
-        realigner = self._realigner_class(
-            input_length=len(tokens),
-            output_length=len(input_sequence),
+        label_aligner = self._label_aligner_class(
+            input_sequence=input_sequence,
             edit={
-                'replacement_group': inverse_replacement_group,
+                'replacement_group': forward_replacement_group,
                 'span_group': span_group,
             },
+            output_length=len(tokens),
         )
-        return tokens, output_labels, realigner
+
+        return tokens, label_aligner
 
     def _tokenize(self, input_str: str) -> List[str]:
         raise NotImplementedError
 
 
-class TokenizerRealigner(Realigner):
+class TokenizerAligner(LabelAligner):
 
-    def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+    def _transform(self, labels: List[int]):
+        output_labels = propagate_by_replacement_group(
+            labels=labels,
+            replacement_group=self._forward_edit['replacement_group'],
+            transduce_func=self._forward_transduce_func,
+        )
+        output_labels = reduce_by_span_group(output_labels, self._forward_edit['span_group'])
+        return output_labels
+
+    def _forward_reduce_func(self, labels: List[int], output_size: int) -> List[int]:
         raise NotImplementedError
 
-    def _realign_labels(self, labels: List[int]) -> List[int]:
-        output_labels = expand_by_span_group(labels=labels, span_group=self._edit['span_group'])
+    def _inverse_transform(self, labels):
+        inverse_replacement_group = str2str.inverse(
+            self._input_sequence, self._forward_edit['replacement_group'])
+        output_labels = expand_by_span_group(
+            labels=labels,
+            span_group=self._forward_edit['span_group'],
+        )
         output_labels = propagate_by_replacement_group(
             labels=output_labels,
-            replacement_group=self._edit['replacement_group'],
+            replacement_group=inverse_replacement_group,
             transduce_func=self._backward_transduce_func,
         )
         return output_labels
+
+    def _backward_reduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        raise NotImplementedError

--- a/uttut/pipeline/ops/tokenizer.py
+++ b/uttut/pipeline/ops/tokenizer.py
@@ -23,7 +23,7 @@ class Tokenizer(Operator):
         same_label_aligner_class = self._label_aligner_class == other._label_aligner_class
         return same_label_aligner_class and super().__eq__(other)
 
-    def transform(self, input_sequence: str) -> Tuple[List[str], 'LabelAligner']:
+    def _transform(self, input_sequence: str) -> Tuple[List[str], 'LabelAligner']:
 
         tokens = self._tokenize(input_sequence)
 

--- a/uttut/pipeline/ops/whitespace_tokenizer.py
+++ b/uttut/pipeline/ops/whitespace_tokenizer.py
@@ -1,6 +1,6 @@
 from typing import List
 
-from .tokenizer import Tokenizer, TokenizerRealigner
+from .tokenizer import Tokenizer, TokenizerAligner
 from .label_transducer import get_most_common_except_not_entity
 
 
@@ -25,10 +25,9 @@ class WhiteSpaceTokenizer(Tokenizer):
     """
 
     def __init__(self):
-        super().__init__(WhiteSpaceTokenizerRealigner)
+        super().__init__(WhiteSpaceTokenizerAligner)
 
     def _tokenize(self, input_str: str) -> List[str]:
-
         """Split text into list by whitespace characters
 
         E.g.
@@ -40,7 +39,10 @@ class WhiteSpaceTokenizer(Tokenizer):
         return input_str.split()
 
 
-class WhiteSpaceTokenizerRealigner(TokenizerRealigner):
+class WhiteSpaceTokenizerAligner(TokenizerAligner):
+
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        return get_most_common_except_not_entity(labels, output_size)
 
     def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
         return get_most_common_except_not_entity(labels, output_size)

--- a/uttut/pipeline/ops/whitespace_tokenizer.py
+++ b/uttut/pipeline/ops/whitespace_tokenizer.py
@@ -14,12 +14,13 @@ class WhiteSpaceTokenizer(Tokenizer):
     E.g.
     >>> from uttut.pipeline.ops.whitespace_tokenizer import WhiteSpaceTokenizer
     >>> op = WhiteSpaceTokenizer()
-    >>> output_seq, output_labels, realigner = op.transform("a b", [1, 2, 3])
+    >>> output_seq, label_aligner = op.transform("a b")
+    >>> output_labels = label_aligner.transform([1, 2, 3])
     >>> output_seq
     ["a", "b"]
     >>> output_labels
     [1, 3]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 0, 3]
 
     """

--- a/uttut/pipeline/ops/zh_char_tokenizer.py
+++ b/uttut/pipeline/ops/zh_char_tokenizer.py
@@ -14,12 +14,13 @@ class ZhCharTokenizer(EngTokenizer):
     E.g.
     >>> from uttut.pipeline.ops.zh_char_tokenizer import ZhCharTokenizer
     >>> op = ZhCharTokenizer()
-    >>> output_seq, output_labels, realigner = op.transform("這是a b", [1, 2, 3, 4, 5])
+    >>> output_seq, label_aligner = op.transform("這是a b")
+    >>> output_labels = label_aligner.transform([1, 2, 3, 4, 5])
     >>> output_seq
     ["這", "是", "a", "b"]
     >>> output_labels
     [1, 2, 3, 5]
-    >>> realigner(output_labels)
+    >>> label_aligner.inverse_transform(output_labels)
     [1, 2, 3, 0, 5]
 
     """

--- a/uttut/pipeline/step.py
+++ b/uttut/pipeline/step.py
@@ -1,4 +1,3 @@
-from typing import List
 from .ops.base import Operator
 
 
@@ -21,8 +20,5 @@ class Step:
     def output_type(self):
         return self.op.output_type
 
-    def transform(self, input_sequence, labels: List[int]):
-        return self.op.transform(
-            input_sequence=input_sequence,
-            labels=labels,
-        )
+    def transform(self, input_sequence):
+        return self.op.transform(input_sequence=input_sequence)

--- a/uttut/pipeline/tests/mock_factory.py
+++ b/uttut/pipeline/tests/mock_factory.py
@@ -1,12 +1,15 @@
 from typing import List
 
-from ..ops.base import Operator, Realigner
+from ..ops.base import Operator, LabelAligner
 from ..ops.factory import OperatorFactory
 
 
-class MockRealigner(Realigner):
+class MockLabelAligner(LabelAligner):
 
-    def _realign_labels(self, labels: List[int]):
+    def _transform(self, labels):
+        return labels
+
+    def _inverse_transform(self, labels):
         return labels
 
 
@@ -20,10 +23,10 @@ class MockStr2StrOp(Operator):
         same_kwargs = self.kwargs == other.kwargs
         return same_kwargs and super().__eq__(other)
 
-    def transform(self, input_sequence: str, labels: List[int]):  # type: ignore
-        return input_sequence, labels, MockRealigner(
+    def transform(self, input_sequence: str):  # type: ignore
+        return input_sequence, MockLabelAligner(
             edit={},
-            input_length=len(input_sequence),
+            input_sequence=input_sequence,
             output_length=len(input_sequence),
         )
 
@@ -38,10 +41,10 @@ class MockLst2LstOp(Operator):
         same_kwargs = self.kwargs == other.kwargs
         return same_kwargs and super().__eq__(other)
 
-    def transform(self, input_sequence: List[str], labels: List[int]):  # type: ignore
-        return input_sequence, labels, MockRealigner(
+    def transform(self, input_sequence: List[str]):  # type: ignore
+        return input_sequence, MockLabelAligner(
             edit={},
-            input_length=len(input_sequence),
+            input_sequence=input_sequence,
             output_length=len(input_sequence),
         )
 
@@ -56,12 +59,12 @@ class MockStr2LstOp(Operator):
         same_kwargs = self.kwargs == other.kwargs
         return same_kwargs and super().__eq__(other)
 
-    def transform(self, input_sequence: str, labels: List[int]):  # type: ignore
+    def transform(self, input_sequence: str):  # type: ignore
         output_sequence = list(input_sequence)
-        return output_sequence, labels, MockRealigner(
+        return output_sequence, MockLabelAligner(
             edit={},
-            input_length=len(output_sequence),
-            output_length=len(input_sequence),
+            input_sequence=input_sequence,
+            output_length=len(output_sequence),
         )
 
 

--- a/uttut/pipeline/tests/mock_factory.py
+++ b/uttut/pipeline/tests/mock_factory.py
@@ -23,7 +23,7 @@ class MockStr2StrOp(Operator):
         same_kwargs = self.kwargs == other.kwargs
         return same_kwargs and super().__eq__(other)
 
-    def transform(self, input_sequence: str):  # type: ignore
+    def _transform(self, input_sequence: str):  # type: ignore
         return input_sequence, MockLabelAligner(
             edit={},
             input_sequence=input_sequence,
@@ -41,7 +41,7 @@ class MockLst2LstOp(Operator):
         same_kwargs = self.kwargs == other.kwargs
         return same_kwargs and super().__eq__(other)
 
-    def transform(self, input_sequence: List[str]):  # type: ignore
+    def _transform(self, input_sequence: List[str]):  # type: ignore
         return input_sequence, MockLabelAligner(
             edit={},
             input_sequence=input_sequence,
@@ -59,7 +59,7 @@ class MockStr2LstOp(Operator):
         same_kwargs = self.kwargs == other.kwargs
         return same_kwargs and super().__eq__(other)
 
-    def transform(self, input_sequence: str):  # type: ignore
+    def _transform(self, input_sequence: str):  # type: ignore
         output_sequence = list(input_sequence)
         return output_sequence, MockLabelAligner(
             edit={},

--- a/uttut/pipeline/tests/test_pipe.py
+++ b/uttut/pipeline/tests/test_pipe.py
@@ -65,38 +65,36 @@ def test_pipe_can_have_duplicated_ops():
 
 
 def test_transform(fake_pipe, dummy_datum):
-    output_seq, intent_labels, entity_labels, realigner, intermediate = fake_pipe.transform(
+    output_seq, intent_labels, entity_labels, label_aligner, intermediate = fake_pipe.transform(
         dummy_datum)
 
     assert output_seq == ['1', '2', '3']
     assert intent_labels == [1]
     assert entity_labels == [1, 2, 3]
-    assert [('123', [1, 2, 3]), ('123', [1, 2, 3]),
-            (['1', '2', '3'], [1, 2, 3]), (['1', '2', '3'], [1, 2, 3])] == intermediate[:]
+    assert ['123', '123', ['1', '2', '3'], ['1', '2', '3']] == intermediate[:]
 
-    output = realigner(entity_labels)
+    output = label_aligner.inverse_transform(entity_labels)
     assert output == [1, 2, 3]
 
 
 def test_transform_with_checkpoints(fake_pipe_with_checkpoints, dummy_datum):
     output = fake_pipe_with_checkpoints.transform(dummy_datum)
-    output_seq, intent_labels, entity_labels, realigner, intermediate = output
+    output_seq, intent_labels, entity_labels, label_aligner, intermediate = output
 
     assert output_seq == ['1', '2', '3']
     assert intent_labels == [1]
     assert entity_labels == [1, 2, 3]
 
     # intermediate
-    assert ('123', [1, 2, 3]) == intermediate.get_from_checkpoint('1')
-    assert (['1', '2', '3'], [1, 2, 3]) == intermediate.get_from_checkpoint('2')
-    assert [('123', [1, 2, 3]), ('123', [1, 2, 3]),
-            (['1', '2', '3'], [1, 2, 3]), (['1', '2', '3'], [1, 2, 3])] == intermediate[:]
+    assert '123' == intermediate.get_from_checkpoint('1')
+    assert ['1', '2', '3'] == intermediate.get_from_checkpoint('2')
+    assert ['123', '123', ['1', '2', '3'], ['1', '2', '3']] == intermediate[:]
 
     with pytest.raises(KeyError):
         intermediate.get_from_checkpoint('薄餡亂入')
 
     # realign labels
-    output = realigner(entity_labels)
+    output = label_aligner.inverse_transform(entity_labels)
     assert output == [1, 2, 3]
 
 

--- a/uttut/pipeline/tests/test_step.py
+++ b/uttut/pipeline/tests/test_step.py
@@ -16,7 +16,7 @@ class MockedOperator(Operator):
         same_state = self.state == other.state
         return same_state and super().__eq__(other)
 
-    def transform(self, input_sequence, labels):
+    def transform(self, input_sequence):
         pass
 
 
@@ -32,8 +32,8 @@ def test_not_equal(step):
 
 def test_transform(step, mocker):
     mock_method = mocker.patch.object(step.op, 'transform')
-    step.transform('abc', [1, 2, 3])
-    mock_method.assert_called_once_with(input_sequence='abc', labels=[1, 2, 3])
+    step.transform('abc')
+    mock_method.assert_called_once_with(input_sequence='abc')
 
 
 def test_attributes(step):

--- a/uttut/pipeline/tests/test_step.py
+++ b/uttut/pipeline/tests/test_step.py
@@ -16,7 +16,7 @@ class MockedOperator(Operator):
         same_state = self.state == other.state
         return same_state and super().__eq__(other)
 
-    def transform(self, input_sequence):
+    def _transform(self, input_sequence):
         pass
 
 


### PR DESCRIPTION
Main Modifications:
1. The interface of the `Operator` has huge breaking.
- The output of the method `transform` is changed.
  **Before**: output_seq, output_labels, realigner 
  **Now**: output_seq, label_aligner

- The function of the method `transform` is more limited.
  **Before**: Operator transform would do 
      (1) generate forward edit
      (2) transform input sequence to output sequence given forward edit
      (3) generate inverse edit
      (4) updated labels given forward edit
      (5) generate Label Realigner
  **Now**:
      Keep (1) (2) and generate LabelAligner
      LabelAligner would do (3) and (4) outside of `Operator.transform`.
                  
2. LabelAligner substitutes Realigner
LabelAligner will update raw labels when the method `transform` is called. 
Moreover, LabelAligner will realign model prediction when the method `inverse_transform` is called.

3. Pipe has extra method - `transform_sequence`
This method is a cheaper version of `transform`. It takes a raw sequence as input. Also, it returns the transformed sequence, an instance of LabelAlignerSequence and intermediate. 
- data without label
If you just have a sequence-like data without the label, you can ignore the second output.
- data with label
If you have labels, which has the same length as that of the input sequence, you can use the second output - label_aligner to obtain the updated labels using the method of `transform`. Whatsmore, you can realign the model prediction to the original one using the method of `inverse_transform`.