### PR TITLE
version 1.3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,7 @@ else:
 
 setup(
     name="uttut",
-    version='1.3.1',
+    version='1.3.2',
     description="Yoctol Utterance processing utilities",
     license="MIT",
     author="cph",


### PR DESCRIPTION
多一個op token2index 遇到 oov 就 hash
```
d54b898 (HEAD -> version_132, tag: 1.3.2, origin/version_132) version 1.3.2
4f50c5b (origin/master, origin/HEAD, master) Merge pull request #96 from Yoctol/token2index_hash_unknown
4b8f47e (origin/token2index_hash_unknown, token2index_hash_unknown) register to factory
86f192f added docstring
e6ac5e2 added token to index with hash
9ff8ade (customized_word_level_tokenizer) Merge pull request #95 from Yoctol/version_131

```