### PR TITLE
Refactor Step Info

### DIFF
--- a/uttut/pipeline/__init__.py
+++ b/uttut/pipeline/__init__.py
@@ -1,0 +1,1 @@
+from . import ops

--- a/uttut/pipeline/ops/__init__.py
+++ b/uttut/pipeline/ops/__init__.py
@@ -1,3 +1,5 @@
+from .base import Operator
+
 from .lowercase import Lowercase
 from .add_whitespace_around_cjk import AddWhitespaceAroundCJK
 from .add_whitespace_around_punctuation import AddWhitespaceAroundPunctuation
@@ -25,5 +27,3 @@ from .pad import Pad
 from .token_to_index import Token2Index
 from .span_subwords import SpanSubwords
 from .token_to_index_with_hash import Token2IndexwithHash
-
-from .base import op_factory

--- a/uttut/pipeline/ops/add_sos_eos.py
+++ b/uttut/pipeline/ops/add_sos_eos.py
@@ -39,11 +39,6 @@ class AddSosEos(Operator):
         self.start_token = start_token
         self.end_token = end_token
 
-    def __eq__(self, other):
-        same_start_token = self.start_token == other.start_token
-        same_end_token = self.end_token == other.end_token
-        return same_start_token and same_end_token and super().__eq__(other)
-
     def _transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = lst2lst.apply(input_sequence, forward_replacement_group)

--- a/uttut/pipeline/ops/base.py
+++ b/uttut/pipeline/ops/base.py
@@ -70,8 +70,8 @@ class Operator(abc.ABC):
                 f"Concrete class: {cls} should declare `{attr_name}`!"
 
     @classmethod
-    def deserialize(cls, param_str: str):
-        params = json.loads(param_str)
+    def deserialize(cls, serialized_str: str):
+        params = json.loads(serialized_str)
         return cls.from_dict(params)
 
     @staticmethod

--- a/uttut/pipeline/ops/base.py
+++ b/uttut/pipeline/ops/base.py
@@ -85,9 +85,7 @@ class Operator(ABC):
         return self._configs
 
     def __eq__(self, other):
-        self_attrs = (self._input_type, self._output_type)
-        other_attrs = (other._input_type, other._output_type)
-        return self_attrs == other_attrs
+        return type(self) == type(other) and self.configs == other.configs
 
     @property
     def input_type(self):

--- a/uttut/pipeline/ops/pad.py
+++ b/uttut/pipeline/ops/pad.py
@@ -35,11 +35,6 @@ class Pad(Operator):
         self.pad_token = pad_token
         self.maxlen = maxlen
 
-    def __eq__(self, other):
-        same_pad_token = self.pad_token == other.pad_token
-        same_maxlen = self.maxlen == other.maxlen
-        return same_pad_token and same_maxlen and super().__eq__(other)
-
     def _transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
 
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)

--- a/uttut/pipeline/ops/pattern_recognizers/base.py
+++ b/uttut/pipeline/ops/pattern_recognizers/base.py
@@ -26,10 +26,6 @@ class PatternRecognizer(Operator):
             return
         cls.assert_has_class_attributes(['_label_aligner_class'])
 
-    def __eq__(self, other):
-        same_label_aligner_class = self._label_aligner_class == other._label_aligner_class
-        return same_label_aligner_class and super().__eq__(other)
-
     def _transform(self, input_sequence: str) -> Tuple[str, 'LabelAligner']:
         forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
         output_sequence = str2str.apply(input_sequence, forward_replacement_group)

--- a/uttut/pipeline/ops/span_subwords.py
+++ b/uttut/pipeline/ops/span_subwords.py
@@ -49,12 +49,6 @@ class SpanSubwords(Operator):
         self.unk_token = unk_token
         self.maxlen_per_token = maxlen_per_token
 
-    def __eq__(self, other):
-        same_vocab = self.vocab == other.vocab
-        same_unk_token = self.unk_token == other.unk_token
-        same_maxlen_per_token = self.maxlen_per_token == other.maxlen_per_token
-        return same_vocab and same_unk_token and same_maxlen_per_token and super().__eq__(other)
-
     def _transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
         """
         # Requirement: All elements in input_sequence should not contain

--- a/uttut/pipeline/ops/tests/test_add_sos_eos.py
+++ b/uttut/pipeline/ops/tests/test_add_sos_eos.py
@@ -1,6 +1,7 @@
 import pytest
 
 from ..add_sos_eos import AddSosEos
+from ..tokens import START_TOKEN, END_TOKEN
 from .common_tests import OperatorTestTemplate, ParamTuple
 
 
@@ -23,3 +24,32 @@ class TestAddSosEos(OperatorTestTemplate):
     def test_not_equal(self, op):
         custom_op = AddSosEos(start_token='custom_SOS', end_token='custom_EOS')
         assert custom_op != op
+
+
+@pytest.mark.parametrize(
+    "op, expected_configs",
+    [
+        pytest.param(
+            AddSosEos(),
+            {'start_token': START_TOKEN, 'end_token': END_TOKEN},
+            id="default",
+        ),
+        pytest.param(
+            AddSosEos('1', '2'),
+            {'start_token': '1', 'end_token': '2'},
+            id="no keywords",
+        ),
+        pytest.param(
+            AddSosEos('1'),
+            {'start_token': '1', 'end_token': END_TOKEN},
+            id="partial input",
+        ),
+        pytest.param(
+            AddSosEos(end_token='2', start_token='1'),
+            {'start_token': '1', 'end_token': '2'},
+            id="input with key",
+        ),
+    ],
+)
+def test_correct_configs(op, expected_configs):
+    assert op.configs == expected_configs

--- a/uttut/pipeline/ops/tests/test_pad.py
+++ b/uttut/pipeline/ops/tests/test_pad.py
@@ -50,3 +50,27 @@ class TestPad(OperatorTestTemplate):
         op3 = Pad(maxlen=10)
         assert op1 != op2
         assert op2 != op3
+
+
+@pytest.mark.parametrize(
+    "op, expected_configs",
+    [
+        pytest.param(
+            Pad(5),
+            {'pad_token': PAD_TOKEN, 'maxlen': 5},
+            id="default token",
+        ),
+        pytest.param(
+            Pad(10, 'PAD'),
+            {'pad_token': 'PAD', 'maxlen': 10},
+            id="input without key",
+        ),
+        pytest.param(
+            Pad(pad_token='PAD', maxlen=1),
+            {'pad_token': 'PAD', 'maxlen': 1},
+            id="input with key",
+        ),
+    ],
+)
+def test_correct_configs(op, expected_configs):
+    assert op.configs == expected_configs

--- a/uttut/pipeline/ops/tests/test_token_to_index.py
+++ b/uttut/pipeline/ops/tests/test_token_to_index.py
@@ -54,3 +54,33 @@ class TestToken2Index(OperatorTestTemplate):
         op3 = Token2Index(token2index={'薄餡': 0, UNK_TOKEN: 1})
         assert op1 != op2
         assert op2 != op3
+
+
+@pytest.mark.parametrize(
+    "op, expected_configs",
+    [
+        pytest.param(
+            Token2Index(token2index={'薄餡': 0, '要': 1, '帶': 2, '妹': 3, UNK_TOKEN: 4}),
+            {
+                'token2index': {'薄餡': 0, '要': 1, '帶': 2, '妹': 3, UNK_TOKEN: 4},
+                'unk_token': UNK_TOKEN,
+            },
+            id="default token",
+        ),
+        pytest.param(
+            Token2Index({'薄餡': 0, '要': 1, '帶': 2, '妹': 3, '<pad>': 4}, '<pad>'),
+            {
+                'token2index': {'薄餡': 0, '要': 1, '帶': 2, '妹': 3, '<pad>': 4},
+                'unk_token': '<pad>',
+            },
+            id="input without key",
+        ),
+        pytest.param(
+            Token2Index(unk_token='PAD', token2index={'薄餡': 0, 'PAD': 1}),
+            {'unk_token': 'PAD', 'token2index': {'薄餡': 0, 'PAD': 1}},
+            id="input with key",
+        ),
+    ],
+)
+def test_correct_configs(op, expected_configs):
+    assert op.configs == expected_configs

--- a/uttut/pipeline/ops/token_to_index.py
+++ b/uttut/pipeline/ops/token_to_index.py
@@ -47,11 +47,6 @@ class Token2Index(Operator):
         self.token2index = token2index
         self.unk_token = unk_token
 
-    def __eq__(self, other):
-        same_token2index = self.token2index == other.token2index
-        same_unk_token = self.unk_token == other.unk_token
-        return same_token2index and same_unk_token and super().__eq__(other)
-
     def _validate_token2index(self, token2index: Dict[str, int], unk_token: str):
         validate_continuity(token2index)
         if unk_token not in token2index:

--- a/uttut/pipeline/ops/token_to_index_with_hash.py
+++ b/uttut/pipeline/ops/token_to_index_with_hash.py
@@ -38,10 +38,6 @@ class Token2IndexwithHash(Operator):
         self._validate_token2index(token2index)
         self.token2index = token2index
 
-    def __eq__(self, other):
-        same_token2index = self.token2index == other.token2index
-        return same_token2index and super().__eq__(other)
-
     def _validate_token2index(self, token2index: Dict[str, int]):
         validate_continuity(token2index)
 

--- a/uttut/pipeline/ops/tokenizers/base.py
+++ b/uttut/pipeline/ops/tokenizers/base.py
@@ -26,10 +26,6 @@ class Tokenizer(Operator):
             return
         cls.assert_has_class_attributes(['_label_aligner_class'])
 
-    def __eq__(self, other):
-        same_label_aligner_class = self._label_aligner_class == other._label_aligner_class
-        return same_label_aligner_class and super().__eq__(other)
-
     def _transform(self, input_sequence: str) -> Tuple[List[str], 'LabelAligner']:
         tokens = self._tokenize(input_sequence)
 

--- a/uttut/pipeline/pipe.py
+++ b/uttut/pipeline/pipe.py
@@ -4,10 +4,9 @@ import json
 
 from uttut.elements import Datum
 
-from .ops.base import LabelAligner
-from .step import Step
 from .intermediate import Intermediate
-from .ops import Operator
+from .ops.base import LabelAligner, Operator
+from .step import Step
 from .utils import unpack_datum
 
 
@@ -35,7 +34,10 @@ class Pipe:
         if op_kwargs is None:
             op_kwargs = {}
 
-        op = Operator.deserialize({'op_name': op_name, 'op_kwargs': op_kwargs})
+        op = Operator.from_dict({'op_name': op_name, 'op_kwargs': op_kwargs})
+        self.add_op(op, checkpoint=checkpoint)
+
+    def add_op(self, op: Operator, checkpoint: str = None):
         step = Step(op)
 
         if self.steps:
@@ -130,10 +132,8 @@ class Pipe:
         # restore steps
         step_infos = pipe_bundle['steps']
         for step_info in step_infos:
-            pipe.add(
-                op_name=step_info['op_name'],
-                op_kwargs=step_info['op_kwargs'],
-            )
+            op = Operator.deserialize(step_info)
+            pipe.add_op(op)
         # restore checkpoints
         pipe._checkpoints = pipe_bundle['checkpoints']
         return pipe

--- a/uttut/pipeline/tests/__init__.py
+++ b/uttut/pipeline/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import mock_factory

--- a/uttut/pipeline/tests/mock_factory.py
+++ b/uttut/pipeline/tests/mock_factory.py
@@ -1,7 +1,6 @@
 from typing import List
 
 from ..ops.base import Operator, LabelAligner
-from ..ops.factory import OperatorFactory
 
 
 class MockLabelAligner(LabelAligner):
@@ -13,17 +12,13 @@ class MockLabelAligner(LabelAligner):
         return labels
 
 
-class MockStr2StrOp(Operator):
+class Str2Str(Operator):
 
     _input_type = str
     _output_type = str
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
-
-    def __eq__(self, other):
-        same_kwargs = self.kwargs == other.kwargs
-        return same_kwargs and super().__eq__(other)
 
     def _transform(self, input_sequence: str):  # type: ignore
         return input_sequence, MockLabelAligner(
@@ -33,17 +28,13 @@ class MockStr2StrOp(Operator):
         )
 
 
-class MockLst2LstOp(Operator):
+class Lst2Lst(Operator):
 
     _input_type = list
     _output_type = list
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
-
-    def __eq__(self, other):
-        same_kwargs = self.kwargs == other.kwargs
-        return same_kwargs and super().__eq__(other)
 
     def _transform(self, input_sequence: List[str]):  # type: ignore
         return input_sequence, MockLabelAligner(
@@ -53,17 +44,13 @@ class MockLst2LstOp(Operator):
         )
 
 
-class MockStr2LstOp(Operator):
+class Str2Lst(Operator):
 
     _input_type = str
     _output_type = list
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
-
-    def __eq__(self, other):
-        same_kwargs = self.kwargs == other.kwargs
-        return same_kwargs and super().__eq__(other)
 
     def _transform(self, input_sequence: str):  # type: ignore
         output_sequence = list(input_sequence)
@@ -72,9 +59,3 @@ class MockStr2LstOp(Operator):
             input_sequence=input_sequence,
             output_length=len(output_sequence),
         )
-
-
-mock_factory = OperatorFactory()
-mock_factory.register('Str2Str', MockStr2StrOp)
-mock_factory.register('Lst2Lst', MockLst2LstOp)
-mock_factory.register('Str2Lst', MockStr2LstOp)

--- a/uttut/pipeline/tests/test_pipe.py
+++ b/uttut/pipeline/tests/test_pipe.py
@@ -1,14 +1,12 @@
 import pytest
 
-from uttut.pipeline.ops import op_factory as default_op_factory
 from uttut.elements import Datum, Intent, Entity
 from ..pipe import Pipe
-from .mock_factory import mock_factory
 
 
 @pytest.fixture
 def fake_pipe():
-    p_custom = Pipe(mock_factory)
+    p_custom = Pipe()
     p_custom.add('Str2Str', {'1': 1})
     p_custom.add('Str2Lst', {})
     p_custom.add('Lst2Lst', {})
@@ -17,7 +15,7 @@ def fake_pipe():
 
 @pytest.fixture
 def fake_pipe_with_checkpoints():
-    p_custom = Pipe(mock_factory)
+    p_custom = Pipe()
     p_custom.add('Str2Str', {'1': 1}, checkpoint='1')
     p_custom.add('Str2Lst', {})
     p_custom.add('Lst2Lst', {}, checkpoint='2')
@@ -37,29 +35,22 @@ def dummy_datum():
     )
 
 
-def test_pipe_init_use_correct_factory():
-    p = Pipe()
-    assert p.operator_factory == default_op_factory
-    p_custom = Pipe(mock_factory)
-    assert p_custom.operator_factory == mock_factory
-
-
 def test_pipe_has_invalid_op():
-    p = Pipe(mock_factory)
+    p = Pipe()
     p.add('Lst2Lst')
     with pytest.raises(TypeError):
         p.add('Str2Str')
 
 
 def test_pipe_has_duplicated_checkpoints():
-    p = Pipe(mock_factory)
+    p = Pipe()
     p.add('Str2Str', checkpoint='1')
     with pytest.raises(KeyError):
         p.add('Str2Lst', checkpoint='1')
 
 
 def test_pipe_can_have_duplicated_ops():
-    p = Pipe(mock_factory)
+    p = Pipe()
     p.add('Str2Str', checkpoint='1')
     p.add('Str2Str', checkpoint='2')
 
@@ -100,11 +91,11 @@ def test_transform_with_checkpoints(fake_pipe_with_checkpoints, dummy_datum):
 
 def test_serialization(fake_pipe):
     serialized_str = fake_pipe.serialize()
-    o_pipe = Pipe.deserialize(serialized_str, mock_factory)
+    o_pipe = Pipe.deserialize(serialized_str)
     assert fake_pipe == o_pipe
 
 
 def test_serialization_with_checkpoint(fake_pipe_with_checkpoints):
     serialized_str = fake_pipe_with_checkpoints.serialize()
-    o_pipe = Pipe.deserialize(serialized_str, mock_factory)
+    o_pipe = Pipe.deserialize(serialized_str)
     assert fake_pipe_with_checkpoints == o_pipe


### PR DESCRIPTION
讓 Operator 自帶 serialize, deserialize 加強封裝性
並移除 _step_info (用 step.op.configs 取代)
`__eq__` 也可以用 configs 做

Pipe 先移除了 custom_op_factory，日後有需求的話再想辦法加入
加上數個 property 來加強外部存取方便性

下一 PR 會進一步把 Step 拿掉

