### PR TITLE
Num token

### DIFF
--- a/uttut/pipeline/ops/__init__.py
+++ b/uttut/pipeline/ops/__init__.py
@@ -11,6 +11,7 @@ from .pattern_recognizers import (
     FloatToken,
     IntTokenWithSpace,
     FloatTokenWithSpace,
+    NumTokenWithSpace,
     MergeWhiteSpaceCharacters,
     StripWhiteSpaceCharacters,
     StopwordsToWhitespace,

--- a/uttut/pipeline/ops/pattern_recognizers/__init__.py
+++ b/uttut/pipeline/ops/pattern_recognizers/__init__.py
@@ -5,3 +5,4 @@ from .float_token_with_space import FloatTokenWithSpace
 from .merge_whitespace_characters import MergeWhiteSpaceCharacters
 from .strip_whitespace_characters import StripWhiteSpaceCharacters
 from .stopwords_to_whitespace import StopwordsToWhitespace
+from .num_token_with_space import NumTokenWithSpace

--- a/uttut/pipeline/ops/pattern_recognizers/num_token_with_space.py
+++ b/uttut/pipeline/ops/pattern_recognizers/num_token_with_space.py
@@ -28,7 +28,7 @@ class NumTokenWithSpace(PatternRecognizer):
 
     """
     Recognize integer (ex: 12, 10000) in the input string
-    and replace them with NUM_TOKEN_WTIH_SPACE ( _int_ )
+    and replace them with NUM_TOKEN_WTIH_SPACE ( _num_ )
 
     E.g.
     >>> from uttut.pipeline.ops.num_token_with_space import NumTokenWithSpace

--- a/uttut/pipeline/ops/pattern_recognizers/num_token_with_space.py
+++ b/uttut/pipeline/ops/pattern_recognizers/num_token_with_space.py
@@ -1,0 +1,57 @@
+from typing import List
+
+import re
+from collections import Counter
+
+from uttut import ENTITY_LABEL
+from ..label_transducer import get_most_common_except_not_entity
+from ..tokens import NUM_TOKEN_WITH_SPACE
+from .base import PatternRecognizer, PatternRecognizerAligner
+
+
+class NumTokenWithSpaceAligner(PatternRecognizerAligner):
+
+    def _forward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        token = NumTokenWithSpace.TOKEN
+        counter = Counter(labels)
+        common_label = counter.most_common()[0][0]
+        token_len = len(token) - 2
+        output_label = [ENTITY_LABEL['NOT_ENTITY']] + \
+            [common_label] * token_len + [ENTITY_LABEL['NOT_ENTITY']]
+        return output_label
+
+    def _backward_transduce_func(self, labels: List[int], output_size: int) -> List[int]:
+        return get_most_common_except_not_entity(labels, output_size)
+
+
+class NumTokenWithSpace(PatternRecognizer):
+
+    """
+    Recognize integer (ex: 12, 10000) in the input string
+    and replace them with NUM_TOKEN_WTIH_SPACE ( _int_ )
+
+    E.g.
+    >>> from uttut.pipeline.ops.num_token_with_space import NumTokenWithSpace
+    >>> op = NumTokenWithSpace()
+    >>> output_seq, label_aligner = op.transform("10")
+    >>> output_labels = label_aligner.transform([1, 1])
+    >>> output_seq
+    " _num_ "
+    >>> output_labels
+    [0, 1, 1, 1, 1, 1, 0]
+    >>> label_aligner.inverse_transform(output_labels)
+    [1, 1]
+
+    # Note: It is designed for a substitution of `Purewords`.
+
+    """
+
+    REGEX_PATTERN = re.compile(r"(?<![\.\d\uFF10-\uFF19])[\d\uFF10-\uFF19]+(?![\.\d\uFF10-\uFF19])")
+    TOKEN = NUM_TOKEN_WITH_SPACE
+    _label_aligner_class = NumTokenWithSpaceAligner
+
+    def _gen_forward_replacement_group(self, input_str: str):  # type: ignore
+        return super()._gen_forward_replacement_group(
+            input_str=input_str,
+            annotation='num-token-with-space',
+        )

--- a/uttut/pipeline/ops/pattern_recognizers/tests/test_num_token_with_space.py
+++ b/uttut/pipeline/ops/pattern_recognizers/tests/test_num_token_with_space.py
@@ -1,0 +1,87 @@
+import pytest
+
+from ...tests.common_tests import OperatorTestTemplate, ParamTuple
+from ..num_token_with_space import NumTokenWithSpace
+
+
+class TestNumTokenWithSpace(OperatorTestTemplate):
+
+    params = [
+        ParamTuple(
+            "12 24 3666",
+            [1, 1, 0, 2, 2, 0, 3, 3, 3, 3],
+            " _num_   _num_   _num_ ",
+            [0, 1, 1, 1, 1, 1, 0, 0, 0, 2, 2, 2, 2, 2, 0, 0, 0, 3, 3, 3, 3, 3, 0],
+            id='num num num',
+        ),
+        ParamTuple(
+            "１２ ２４ ３６６６",
+            [1, 1, 0, 2, 2, 0, 3, 3, 3, 3],
+            " _num_   _num_   _num_ ",
+            [0, 1, 1, 1, 1, 1, 0, 0, 0, 2, 2, 2, 2, 2, 0, 0, 0, 3, 3, 3, 3, 3, 0],
+            id='fullwidth-fnum num num',
+        ),
+        ParamTuple(
+            "12.3 1000 3.5",
+            [1, 1, 1, 1, 0, 2, 2, 2, 2, 0, 3, 3, 3],
+            "12.3  _num_  3.5",
+            [1, 1, 1, 1, 0, 0, 2, 2, 2, 2, 2, 0, 0, 3, 3, 3],
+            id='float num float',
+        ),
+        ParamTuple(
+            "１２.３ １０００ ３.５",
+            [1, 1, 1, 1, 0, 2, 2, 2, 2, 0, 3, 3, 3],
+            "１２.３  _num_  ３.５",
+            [1, 1, 1, 1, 0, 0, 2, 2, 2, 2, 2, 0, 0, 3, 3, 3],
+            id='fullwidth-float num float',
+        ),
+        ParamTuple(
+            "999",
+            [0, 0, 0],
+            " _num_ ",
+            [0, 0, 0, 0, 0, 0, 0],
+            id='num with label 0',
+        ),
+        ParamTuple(
+            "９９９",
+            [0, 0, 0],
+            " _num_ ",
+            [0, 0, 0, 0, 0, 0, 0],
+            id='fullwidth-num with label 0',
+        ),
+        ParamTuple(
+            "０１2３４5６7８９",
+            [3 for _ in range(10)],
+            " _num_ ",
+            [0, 3, 3, 3, 3, 3, 0],
+            id='fullwidth, halfwidth mixture',
+        ),
+        ParamTuple(
+            "GB亂入",
+            [1, 1, 2, 2],
+            "GB亂入",
+            [1, 1, 2, 2],
+            id='identity',
+        ),
+        ParamTuple(
+            "GB亂入10次",
+            [1, 1, 2, 2, 3, 3, 4],
+            "GB亂入 _num_ 次",
+            [1, 1, 2, 2, 0, 3, 3, 3, 3, 3, 0, 4],
+            id='zh with num',
+        ),
+        ParamTuple(
+            "GB亂入１０次",
+            [1, 1, 2, 2, 3, 3, 4],
+            "GB亂入 _num_ 次",
+            [1, 1, 2, 2, 0, 3, 3, 3, 3, 3, 0, 4],
+            id='zh with fullwidth-num',
+        ),
+    ]
+
+    @pytest.fixture(scope='class')
+    def op(self):
+        return NumTokenWithSpace()
+
+    def test_equal(self, op):
+        assert NumTokenWithSpace() == op

--- a/uttut/pipeline/ops/tokens.py
+++ b/uttut/pipeline/ops/tokens.py
@@ -1,9 +1,10 @@
 # numerical tokens
 INT_TOKEN = "_int_"
 FLOAT_TOKEN = "_float_"
+NUM_TOKEN = "_num_"
 INT_TOKEN_WITH_SPACE = f" {INT_TOKEN} "
 FLOAT_TOKEN_WITH_SPACE = f" {FLOAT_TOKEN} "
-
+NUM_TOKEN_WITH_SPACE = f" {NUM_TOKEN} "
 
 #
 START_TOKEN = "<sos>"


### PR DESCRIPTION
# NumberTokenWithSpace
#### Recognize integer (ex: 12, 10000) in the input string and replace them with NUM_TOKEN_WTIH_SPACE ( `_num_` )

```python
    >>> from uttut.pipeline.ops.num_token_with_space import NumTokenWithSpace
    >>> op = NumTokenWithSpace()
    >>> output_seq, label_aligner = op.transform("10")
    >>> output_labels = label_aligner.transform([1, 1])
    >>> output_seq
    " _num_ "
    >>> output_labels
    [0, 1, 1, 1, 1, 1, 0]
    >>> label_aligner.inverse_transform(output_labels)
    [1, 1]

    # Note: It is designed for a substitution of `Purewords`.
```
