### PR TITLE
added pure number to token operator

### DIFF
--- a/uttut/pipeline/ops/__init__.py
+++ b/uttut/pipeline/ops/__init__.py
@@ -29,4 +29,4 @@ from .pad import Pad
 from .token_to_index import Token2Index
 from .span_subwords import SpanSubwords
 from .token_to_index_with_hash import Token2IndexwithHash
-from .pure_num_to_token import PureNumtoToken
+from .pure_num_to_token import PureNum2Token

--- a/uttut/pipeline/ops/__init__.py
+++ b/uttut/pipeline/ops/__init__.py
@@ -29,3 +29,4 @@ from .pad import Pad
 from .token_to_index import Token2Index
 from .span_subwords import SpanSubwords
 from .token_to_index_with_hash import Token2IndexwithHash
+from .pure_num_to_token import PureNumtoToken

--- a/uttut/pipeline/ops/pure_num_to_token.py
+++ b/uttut/pipeline/ops/pure_num_to_token.py
@@ -17,12 +17,13 @@ class PureNum2Token(Operator):
     def __init__(self, token: str = None):
         """
 
-        Recognize string in a list and replace it with a special token (_num_)
-        if the whole string are pure digits.
+        Given a list of strings, replace strings which have only
+        numeric characters with special tokens (`_num_`).
+        "Numeric characters" refers to 0-9, including full-width digits.
 
         E.g.
-        >>> from uttut.pipeline.ops.pure_num_to_token import PureNumtoToken
-        >>> op = PureNumtoToken()
+        >>> from uttut.pipeline.ops.pure_num_to_token import PureNum2Token
+        >>> op = PureNum2Token()
         >>> output_seq, output_labels, realigner = op.transform(
         ["I", "like", "10", "W9", "apples", "300g", "."])
         >>> output_labels = label_aligner.transform([1, 2, 3, 4, 5, 6, 7])

--- a/uttut/pipeline/ops/pure_num_to_token.py
+++ b/uttut/pipeline/ops/pure_num_to_token.py
@@ -16,17 +16,22 @@ class PureNumtoToken(Operator):
 
     def __init__(self, token: str = None):
         """
+
+        Recognize string in a list and replace it with a special token (_num_)
+        if the whole string are pure digits.
+
         E.g.
-        >>> from uttut.pipeline.ops.span_subwords import SpanSubwords
-        >>> op = SpanSubwords(vocab={"I": 0, "apple": 1, "##s": 2}, unk='<unk>', maxlen_per_token=5)
-        >>> output_seq, output_labels, realigner = op.transform(["I", "like", "apples"])
-        >>> output_labels = label_aligner.transform([1, 2, 3])
+        >>> from uttut.pipeline.ops.pure_num_to_token import PureNumtoToken
+        >>> op = PureNumtoToken()
+        >>> output_seq, output_labels, realigner = op.transform(
+        ["I", "like", "10", "W9", "apples", "300g", "."])
+        >>> output_labels = label_aligner.transform([1, 2, 3, 4, 5, 6, 7])
         >>> output_seq
-        ["I", "<unk>", "apple", "##s"]
+        ["I", "like", "_num_", "W9", "apples", "300g", "."]
         >>> output_labels
-        [1, 2, 3, 3]
+        [1, 2, 3, 4, 5, 6, 7]
         >>> label_aligner.inverse_transform(output_labels)
-        [1, 2, 3]
+        [1, 2, 3, 4, 5, 6, 7]
 
         """
         if token is None:

--- a/uttut/pipeline/ops/pure_num_to_token.py
+++ b/uttut/pipeline/ops/pure_num_to_token.py
@@ -1,0 +1,64 @@
+import re
+from typing import List, Tuple
+
+from .base import Operator, NullLabelAligner
+from ..edit import lst2lst
+from ..edit.replacement import ReplacementGroup
+from .tokens import NUM_TOKEN
+
+
+class PureNumtoToken(Operator):
+
+    _input_type = list
+    _output_type = list
+
+    REGEX_PATTERN = re.compile(r"[\d\uFF10-\uFF19]+")
+
+    def __init__(self, token: str = None):
+        """
+        E.g.
+        >>> from uttut.pipeline.ops.span_subwords import SpanSubwords
+        >>> op = SpanSubwords(vocab={"I": 0, "apple": 1, "##s": 2}, unk='<unk>', maxlen_per_token=5)
+        >>> output_seq, output_labels, realigner = op.transform(["I", "like", "apples"])
+        >>> output_labels = label_aligner.transform([1, 2, 3])
+        >>> output_seq
+        ["I", "<unk>", "apple", "##s"]
+        >>> output_labels
+        [1, 2, 3, 3]
+        >>> label_aligner.inverse_transform(output_labels)
+        [1, 2, 3]
+
+        """
+        if token is None:
+            token = NUM_TOKEN
+        self.token = token
+
+    def _transform(self, input_sequence: List[str]) -> Tuple[List[str], 'LabelAligner']:
+        forward_replacement_group = self._gen_forward_replacement_group(input_sequence)
+        output_sequence = lst2lst.apply(input_sequence, forward_replacement_group)
+
+        label_aligner = PureNumtoTokenAligner(
+            input_sequence=input_sequence,
+            edit=forward_replacement_group,
+            output_length=len(output_sequence),
+        )
+        return output_sequence, label_aligner
+
+    def _gen_forward_replacement_group(self, input_lst: List[str]) -> ReplacementGroup:
+        replacement_group = ReplacementGroup()
+        for i, token in enumerate(input_lst):
+            # import pdb; pdb.set_trace()
+            found_sent = self.REGEX_PATTERN.findall(token)
+            if len(found_sent) > 0 and found_sent[0] == token:
+                replacement_group.add(
+                    start=i,
+                    end=i + 1,
+                    new_value=[self.token],
+                    annotation=f"pure-number-to-token-{self.token}",
+                )
+        replacement_group.done()
+
+        return replacement_group
+
+
+PureNumtoTokenAligner = NullLabelAligner

--- a/uttut/pipeline/ops/pure_num_to_token.py
+++ b/uttut/pipeline/ops/pure_num_to_token.py
@@ -7,7 +7,7 @@ from ..edit.replacement import ReplacementGroup
 from .tokens import NUM_TOKEN
 
 
-class PureNumtoToken(Operator):
+class PureNum2Token(Operator):
 
     _input_type = list
     _output_type = list

--- a/uttut/pipeline/ops/tests/test_pure_num_to_token.py
+++ b/uttut/pipeline/ops/tests/test_pure_num_to_token.py
@@ -1,0 +1,81 @@
+import pytest
+
+from ..pure_num_to_token import PureNumtoToken
+from .common_tests import OperatorTestTemplate, ParamTuple
+from ..tokens import NUM_TOKEN
+
+
+class TestPureNumtoTokenDefault(OperatorTestTemplate):
+
+    params = [
+        ParamTuple(
+            ["100", "W9", "300g", "123"],
+            [1, 2, 3, 4],
+            [NUM_TOKEN, "W9", "300g", NUM_TOKEN],
+            [1, 2, 3, 4],
+            id="simple",
+        ),
+        ParamTuple(
+            ["繼良", "有", "100", "億", "元"],
+            [1, 2, 3, 4, 5],
+            ["繼良", "有", NUM_TOKEN, "億", "元"],
+            [1, 2, 3, 4, 5],
+            id="zh with pure digits",
+        ),
+        ParamTuple(
+            ["取消", "HSC5", "改", "HSA5"],
+            [1, 2, 3, 4],
+            ["取消", "HSC5", "改", "HSA5"],
+            [1, 2, 3, 4],
+            id="zh with not pure digits",
+        ),
+        ParamTuple(
+            ["GB", "亂入"],
+            [3, 4],
+            ["GB", "亂入"],
+            [3, 4],
+            id="identity",
+        ),
+    ]
+
+    @pytest.fixture(scope='class')
+    def op(self):
+        return PureNumtoToken()
+
+
+class TestPureNumtoTokenCustom(OperatorTestTemplate):
+
+    params = [
+        ParamTuple(
+            ["100", "W9", "300g", "123"],
+            [1, 2, 3, 4],
+            ["123", "W9", "300g", "123"],
+            [1, 2, 3, 4],
+            id="simple",
+        ),
+        ParamTuple(
+            ["繼良", "有", "100", "億", "元"],
+            [1, 2, 3, 4, 5],
+            ["繼良", "有", "123", "億", "元"],
+            [1, 2, 3, 4, 5],
+            id="zh with pure digits",
+        ),
+        ParamTuple(
+            ["取消", "HSC5", "改", "HSA5"],
+            [1, 2, 3, 4],
+            ["取消", "HSC5", "改", "HSA5"],
+            [1, 2, 3, 4],
+            id="zh with not pure digits",
+        ),
+        ParamTuple(
+            ["GB", "亂入"],
+            [3, 4],
+            ["GB", "亂入"],
+            [3, 4],
+            id="identity",
+        ),
+    ]
+
+    @pytest.fixture(scope='class')
+    def op(self):
+        return PureNumtoToken(token='123')

--- a/uttut/pipeline/ops/tests/test_pure_num_to_token.py
+++ b/uttut/pipeline/ops/tests/test_pure_num_to_token.py
@@ -1,11 +1,11 @@
 import pytest
 
-from ..pure_num_to_token import PureNumtoToken
+from ..pure_num_to_token import PureNum2Token
 from .common_tests import OperatorTestTemplate, ParamTuple
 from ..tokens import NUM_TOKEN
 
 
-class TestPureNumtoTokenDefault(OperatorTestTemplate):
+class TestPureNum2TokenDefault(OperatorTestTemplate):
 
     params = [
         ParamTuple(
@@ -68,10 +68,10 @@ class TestPureNumtoTokenDefault(OperatorTestTemplate):
 
     @pytest.fixture(scope='class')
     def op(self):
-        return PureNumtoToken()
+        return PureNum2Token()
 
 
-class TestPureNumtoTokenCustom(OperatorTestTemplate):
+class TestPureNum2TokenCustom(OperatorTestTemplate):
 
     params = [
         ParamTuple(
@@ -106,4 +106,4 @@ class TestPureNumtoTokenCustom(OperatorTestTemplate):
 
     @pytest.fixture(scope='class')
     def op(self):
-        return PureNumtoToken(token='123')
+        return PureNum2Token(token='123')

--- a/uttut/pipeline/ops/tests/test_pure_num_to_token.py
+++ b/uttut/pipeline/ops/tests/test_pure_num_to_token.py
@@ -9,18 +9,32 @@ class TestPureNumtoTokenDefault(OperatorTestTemplate):
 
     params = [
         ParamTuple(
-            ["100", "W9", "300g", "123"],
-            [1, 2, 3, 4],
-            [NUM_TOKEN, "W9", "300g", NUM_TOKEN],
-            [1, 2, 3, 4],
+            ["100", "W9", "300g", "123", "37.6"],
+            [1, 2, 3, 4, 5],
+            [NUM_TOKEN, "W9", "300g", NUM_TOKEN, "37.6"],
+            [1, 2, 3, 4, 5],
             id="simple",
         ),
         ParamTuple(
-            ["繼良", "有", "100", "億", "元"],
+            ["１００", "W９", "３００g", "１２３", "３７.６"],
+            [1, 2, 3, 4, 5],
+            [NUM_TOKEN, "W９", "３００g", NUM_TOKEN, "３７.６"],
+            [1, 2, 3, 4, 5],
+            id="fullwidth-simple",
+        ),
+        ParamTuple(
+            ["繼良", "有", "1234567890", "億", "元"],
             [1, 2, 3, 4, 5],
             ["繼良", "有", NUM_TOKEN, "億", "元"],
             [1, 2, 3, 4, 5],
             id="zh with pure digits",
+        ),
+        ParamTuple(
+            ["繼良", "有", "１２３４５６７８９０", "億", "元"],
+            [1, 2, 3, 4, 5],
+            ["繼良", "有", NUM_TOKEN, "億", "元"],
+            [1, 2, 3, 4, 5],
+            id="zh with pure fullwidth digits",
         ),
         ParamTuple(
             ["取消", "HSC5", "改", "HSA5"],
@@ -28,6 +42,20 @@ class TestPureNumtoTokenDefault(OperatorTestTemplate):
             ["取消", "HSC5", "改", "HSA5"],
             [1, 2, 3, 4],
             id="zh with not pure digits",
+        ),
+        ParamTuple(
+            ["取消", "HSC５", "改", "HSA５"],
+            [1, 2, 3, 4],
+            ["取消", "HSC５", "改", "HSA５"],
+            [1, 2, 3, 4],
+            id="zh with not pure fullwidth digits",
+        ),
+        ParamTuple(
+            ["1２3４５６78９０"],
+            [1],
+            [NUM_TOKEN],
+            [1],
+            id="fullwidth, halfwidth mixture",
         ),
         ParamTuple(
             ["GB", "亂入"],


### PR DESCRIPTION
## PureNum2Token
#### Recognize string in a list and replace it with a special token (`_num_`) if the whole string are pure digits.

```python
        >>> from uttut.pipeline.ops.pure_num_to_token import PureNumtoToken
        >>> op = PureNumtoToken()
        >>> output_seq, output_labels, realigner = op.transform(
        ["I", "like", "10", "W9", "apples", "300g", "."])
        >>> output_labels = label_aligner.transform([1, 2, 3, 4, 5, 6, 7])
        >>> output_seq
        ["I", "like", "_num_", "W9", "apples", "300g", "."]
        >>> output_labels
        [1, 2, 3, 4, 5, 6, 7]
        >>> label_aligner.inverse_transform(output_labels)
        [1, 2, 3, 4, 5, 6, 7]
```