### PR TITLE
fix: fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ else:
 
 
 about = {}
-with open(here.joinpath('uttut', '__version__.py'), 'r') as filep:
+with here.joinpath('uttut', '__version__.py').open('r') as filep:
     exec(filep.read(), about)
 
 setup(


### PR DESCRIPTION
~~`here` 是 `Path`, ~~
~~`open`會丟~~
```
TypeError: invalid file: PosixPath('uttut/__version__.py')
```

那是 python 3.5的問題